### PR TITLE
fix: include pageUrlOverrides in getStaticPaths for production builds

### DIFF
--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -1,7 +1,7 @@
 import { type GetStaticProps } from 'next'
 
 import { NotionPage } from '@/components/NotionPage'
-import { domain, isDev } from '@/lib/config'
+import { domain, isDev, pageUrlOverrides } from '@/lib/config'
 import { getSiteMap } from '@/lib/get-site-map'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
 import { type PageProps, type Params } from '@/lib/types'
@@ -34,13 +34,17 @@ export async function getStaticPaths() {
 
   const siteMap = await getSiteMap()
 
+  // Combine sitemap paths with URL overrides (e.g., /articles, /notes)
+  // URL overrides might not be in the sitemap if not directly linked from root
+  const allPageIds = [
+    ...new Set([
+      ...Object.keys(siteMap.canonicalPageMap),
+      ...Object.keys(pageUrlOverrides)
+    ])  
+  ]
+
   const staticPaths = {
-    paths: Object.keys(siteMap.canonicalPageMap).map((pageId) => ({
-      params: {
-        pageId
-      }
-    })),
-    // paths: [],
+    paths: allPageIds.map((pageId) => ({ params: { pageId } })),
     fallback: true
   }
 


### PR DESCRIPTION
## Problem
URL override paths (e.g., `/articles`, `/notes`) were returning 404 in production but working on localhost.

## Cause
In production, `getStaticPaths` only generates paths from pages reachable within `maxDepth = 1` from the root Notion page. If these pages aren't directly linked from root (e.g., in a toggle or synced block), they won't be pre-rendered at build time.

## Solution
Explicitly include all `pageUrlOverrides` paths in `getStaticPaths`, ensuring they're pre-rendered at build time regardless of their position in the Notion page hierarchy.

## Changes
- Import `pageUrlOverrides` from config
- Combine sitemap paths with URL override paths using a Set for deduplication