### PR TITLE
Mobile list view hover

### DIFF
--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -874,17 +874,11 @@ span[class*='_background'] {
 }
 
 /* iOS Safari can apply sticky hover while finger-scrolling over links.
-   Disable list-row hover feedback on touch devices to prevent false highlights. */
+   Disable list-row hover feedback on touch devices to prevent false highlights,
+   but keep native tap/click feedback for navigation. */
 @media (hover: none) and (pointer: coarse) {
-  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item,
-  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link {
-    -webkit-tap-highlight-color: transparent;
-  }
-
   .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item:hover,
-  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item:active,
-  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link:hover,
-  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link:active {
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link:hover {
     background: transparent !important;
   }
 }

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -873,6 +873,22 @@ span[class*='_background'] {
   }
 }
 
+/* iOS Safari can apply sticky hover while finger-scrolling over links.
+   Disable list-row hover feedback on touch devices to prevent false highlights. */
+@media (hover: none) and (pointer: coarse) {
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item,
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item:hover,
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item:active,
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link:hover,
+  .notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97 .notion-list-item .notion-page-link:active {
+    background: transparent !important;
+  }
+}
+
 .notion-list-item-property {
   /** Vertically align properties on the right of list views */
   display: flex;


### PR DESCRIPTION
#### Description

Fixes an issue on iPhone Safari where scrolling the main home collection list on `wustep.me` would trigger unwanted hover highlights on list items.

This was resolved by adding a touch-device-specific CSS override to `styles/wustep.css`. The override targets devices with no hover capability and coarse pointers (`@media (hover: none) and (pointer: coarse)`), applying `-webkit-tap-highlight-color: transparent` and forcing `background: transparent !important` for hover/active states on list items and links within the specific home collection block (`.notion-block-2bc5cb08cf2c8036a1e3cddcb2c61d97`).

#### Notion Test Page ID

The fix applies to the main home collection displayed on `wustep.me`. The specific Notion block ID targeted by the CSS is `2bc5cb08cf2c8036a1e3cddcb2c61d97`.

---
<p><a href="https://cursor.com/agents?id=bc-0d3d69b7-b50f-4e14-9037-c65aedfca9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d3d69b7-b50f-4e14-9037-c65aedfca9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

