### PR TITLE
External post links in collection views

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -23,6 +23,7 @@ import { useSearchParam } from 'react-use'
 
 import type * as types from '@/lib/types'
 import * as config from '@/lib/config'
+import { getExternalUrlMap } from '@/lib/get-external-url-map'
 import { mapImageUrl } from '@/lib/map-image-url'
 import { getCanonicalPageUrl, mapPageUrl } from '@/lib/map-page-url'
 import { searchNotion } from '@/lib/search-notion'
@@ -217,6 +218,52 @@ export function NotionPage({
   const router = useRouter()
   const lite = useSearchParam('lite')
 
+  // lite mode is for oembed
+  const isLiteMode = lite === 'true'
+
+  const { isDarkMode } = useDarkMode()
+
+  const externalUrlMap = React.useMemo(
+    () => (recordMap ? getExternalUrlMap(recordMap) : new Map<string, string>()),
+    [recordMap]
+  )
+
+  const siteMapPageUrl = React.useMemo(() => {
+    const params: any = {}
+    if (lite) params.lite = lite
+
+    const searchParams = new URLSearchParams(params)
+    if (!site) return undefined
+    const baseMapPageUrl = mapPageUrl(site, recordMap!, searchParams)
+    return (pageId = '') => {
+      const externalUrl = externalUrlMap.get(
+        parsePageId(pageId, { uuid: false })!
+      )
+      if (externalUrl) return externalUrl
+      return baseMapPageUrl(pageId)
+    }
+  }, [site, recordMap, lite, externalUrlMap])
+
+  const ExternalAwarePageLink = React.useMemo(() => {
+    const PageLinkComponent = (props: any) => {
+      const { href, ...rest } = props
+      if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+        return (
+          <a
+            href={href}
+            target='_blank'
+            rel='noopener noreferrer'
+            data-external-link
+            {...rest}
+          />
+        )
+      }
+      return <a href={href} {...rest} />
+    }
+    PageLinkComponent.displayName = 'ExternalAwarePageLink'
+    return PageLinkComponent
+  }, [])
+
   const components = React.useMemo<Partial<NotionComponents>>(
     () => ({
       nextLegacyImage: Image,
@@ -228,26 +275,14 @@ export function NotionPage({
       Modal,
       Tweet,
       Header: NotionPageHeader,
+      PageLink: ExternalAwarePageLink,
       propertyLastEditedTimeValue,
       propertyTextValue,
       propertyDateValue,
       ...componentOverrides
     }),
-    [componentOverrides]
+    [componentOverrides, ExternalAwarePageLink]
   )
-
-  // lite mode is for oembed
-  const isLiteMode = lite === 'true'
-
-  const { isDarkMode } = useDarkMode()
-
-  const siteMapPageUrl = React.useMemo(() => {
-    const params: any = {}
-    if (lite) params.lite = lite
-
-    const searchParams = new URLSearchParams(params)
-    return site ? mapPageUrl(site, recordMap!, searchParams) : undefined
-  }, [site, recordMap, lite])
 
   const keys = Object.keys(recordMap?.block || {})
   const block = getBlockValue(recordMap?.block?.[keys[0]!])
@@ -276,7 +311,25 @@ export function NotionPage({
 
   const footer = React.useMemo(() => <Footer />, [])
 
+  // Redirect to external URL if the page has one configured
+  const externalRedirectUrl = React.useMemo(() => {
+    if (!block || !recordMap) return null
+    const isExternal = getPageProperty<boolean>('External', block, recordMap)
+    if (!isExternal) return null
+    return getPageProperty<string>('External URL', block, recordMap) || null
+  }, [block, recordMap])
+
+  React.useEffect(() => {
+    if (externalRedirectUrl) {
+      window.location.replace(externalRedirectUrl)
+    }
+  }, [externalRedirectUrl])
+
   if (router.isFallback) {
+    return <Loading />
+  }
+
+  if (externalRedirectUrl) {
     return <Loading />
   }
 

--- a/lib/get-external-url-map.ts
+++ b/lib/get-external-url-map.ts
@@ -1,0 +1,35 @@
+import { type ExtendedRecordMap } from 'notion-types'
+import { getBlockValue, getPageProperty, uuidToId } from 'notion-utils'
+
+/**
+ * Builds a map of page IDs to external URLs for pages that have
+ * the "External" checkbox enabled and an "External URL" property set.
+ */
+export function getExternalUrlMap(
+  recordMap: ExtendedRecordMap
+): Map<string, string> {
+  const map = new Map<string, string>()
+
+  for (const blockId of Object.keys(recordMap.block)) {
+    const block = getBlockValue(recordMap.block[blockId])
+    if (!block || block.type !== 'page') continue
+
+    const isExternal = getPageProperty<boolean>(
+      'External',
+      block,
+      recordMap
+    )
+    if (!isExternal) continue
+
+    const externalUrl = getPageProperty<string>(
+      'External URL',
+      block,
+      recordMap
+    )
+    if (externalUrl) {
+      map.set(uuidToId(blockId), externalUrl)
+    }
+  }
+
+  return map
+}

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -952,6 +952,30 @@ span[class*='_background'] {
   padding: 1rem 1.25rem;
 }
 
+/**
+ * ========== External Links in Collections ==========
+ * Show an arrow icon next to titles for posts that link externally.
+ */
+.notion-collection-card[data-external-link] .notion-page-title-text::after,
+.notion-list-item[data-external-link] .notion-list-item-title::after {
+  content: '';
+  display: inline-block;
+  width: 0.65em;
+  height: 0.65em;
+  margin-left: 0.25em;
+  vertical-align: middle;
+  background-color: currentColor;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 17L17 7'/%3E%3Cpath d='M7 7h10v10'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+
+.notion-collection-card[data-external-link]:hover .notion-page-title-text::after,
+.notion-list-item[data-external-link]:hover .notion-list-item-title::after {
+  opacity: 1;
+}
+
 /* Dark mode adjustments */
 .dark-mode .notion-collection-card {
   background: var(--dark-surface);


### PR DESCRIPTION
## Summary
- Posts with an "External" checkbox and "External URL" Notion property now link directly to the external URL in both list and gallery views
- External links open in a new tab with an arrow (↗) icon that appears on hover
- Visiting the page slug directly (e.g. `/some-post`) redirects to the external URL

## Test plan
- [ ] Add "External" (checkbox) and "External URL" (URL) properties to a Posts database entry
- [ ] Verify the post links externally in both list and gallery views
- [ ] Verify the arrow icon appears on hover for external posts
- [ ] Verify visiting the slug directly redirects to the external URL
- [ ] Verify regular (non-external) posts still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)