### PR TITLE
Improve Notion API caching and add docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Docs
+
+Notes on how this site works. Each doc is focused on a single concern and links to the relevant source files.
+
+- [architecture.md](architecture.md) — high-level overview of how data flows from Notion to the browser
+- [routing.md](routing.md) — how a URL becomes a Notion page, including `pageUrlOverrides` and canonical slugs
+- [configuration.md](configuration.md) — `site.config.ts`, `lib/config.ts`, and env vars
+- [caching.md](caching.md) — ISR, CDN headers, in-memory caches, Redis, and Notion client retry/rate-limit
+- [images.md](images.md) — preview images (LQIP), social/OG images, and the signed-URL fix
+- [development.md](development.md) — local setup, commands, debugging tips
+- [styling.md](styling.md) — CSS file structure, Tailwind/shadcn vs. the Notion stylesheet
+- [customizations.md](customizations.md) — this site's extensions on top of nextjs-notion-starter-kit
+
+Start with `architecture.md` if you're new to the repo.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+This is a Next.js (Pages Router) site that renders content authored in Notion. It's a fork of [nextjs-notion-starter-kit](https://github.com/transitive-bullshit/nextjs-notion-starter-kit) with custom styling and a few extensions.
+
+## High-level data flow
+
+```
+Notion workspace
+    ↓ (unofficial API via `notion-client`)
+lib/notion-api.ts        ← retry + rate-limit wrappers
+    ↓
+lib/notion.ts            ← getPage / search with TTL caches
+    ↓
+lib/resolve-notion-page.ts
+    ↓
+pages/[pageId].tsx       ← getStaticProps (ISR, 24h revalidate)
+    ↓
+components/NotionPage    ← react-notion-x renderer
+    ↓
+Browser (HTML + hydrated React)
+```
+
+## Directory layout
+
+| Path | Purpose |
+|---|---|
+| `site.config.ts` | User-facing site configuration (page IDs, domain, social links, etc.) |
+| `lib/config.ts` | Normalizes `site.config.ts` + env vars into typed exports |
+| `lib/notion-api.ts` | `notion` (runtime) and `buildNotion` (build-time, rate-limited) clients |
+| `lib/notion.ts` | `getPage` and `search` wrappers with in-memory TTL caches |
+| `lib/resolve-notion-page.ts` | URL → pageId → recordMap pipeline, with Redis URI cache |
+| `lib/get-site-map.ts` | Fans out from root page to build `pageMap` + `canonicalPageMap` |
+| `lib/preview-images.ts` | LQIP placeholder generation for images, stored via Keyv |
+| `lib/acl.ts` | Workspace-scoping check (rejects pages from other Notion workspaces) |
+| `lib/map-page-url.ts` | pageId → URL mapping (honors `pageUrlOverrides`) |
+| `pages/[pageId].tsx` | The catch-all Notion page route |
+| `pages/index.tsx` | Custom homepage (static, no Notion fetch) |
+| `pages/feed.tsx` | RSS feed from the Posts collection |
+| `pages/sitemap.xml.tsx` | Sitemap generated from `getSiteMap()` |
+| `pages/api/search-notion.ts` | Proxy for Notion search (currently disabled via config) |
+| `pages/api/social-image.tsx` | Edge-runtime OG image generator (uses `next/og`) |
+| `components/NotionPage.tsx` | The main page shell wrapping `react-notion-x` |
+
+## Rendering modes
+
+- **Homepage (`/`)** — pure static, no Notion data. See [`pages/index.tsx`](../pages/index.tsx).
+- **Notion pages (`/[pageId]`)** — ISR with 24h revalidate. Built paths come from `getSiteMap()`; unknown slugs fall through to `fallback: true`.
+- **Sitemap / feed** — `getServerSideProps` with long CDN `Cache-Control`. They never execute per-request under normal load.
+- **Social image** — edge API route using `next/og`, regenerated on demand and cached by the CDN.
+- **Search** — client calls `/api/search-notion`, which proxies to Notion. Currently disabled (`isSearchEnabled: false`).
+
+## The unofficial Notion API
+
+This site uses [`notion-client`](https://github.com/NotionX/react-notion-x/tree/master/packages/notion-client), which scrapes Notion's public frontend API. That means:
+
+- No API token needed — pages just need to be publicly shared.
+- Rich block types supported by `react-notion-x` render well; custom Notion blocks may not.
+- Rate limits are on Notion's end (~300 req / 300s). See [caching.md](caching.md) for the mitigation stack.
+- `signed_urls` (AWS S3 URLs for uploaded images) expire. See [images.md](images.md) for how we handle that.
+
+## Build vs. runtime
+
+Two distinct phases use different Notion clients:
+
+- **Build time** (`next build`): `getStaticPaths` calls `getSiteMap()`, which walks every page. Uses `buildNotion` — serializes all fetches 1.1s apart and retries 429s up to 5× with exponential backoff.
+- **Runtime** (ISR revalidation, API routes): Uses `notion` — retries once after 1.1s on 429/5xx.
+
+See [`lib/notion-api.ts`](../lib/notion-api.ts).
+
+## Third-party integrations
+
+Listed here for orientation; most are optional and gated on env vars.
+
+- **Redis (Keyv)** — `REDIS_HOST` + `REDIS_PASSWORD`. Currently disabled.
+- **Fathom Analytics** — `NEXT_PUBLIC_FATHOM_ID`.
+- **PostHog** — `NEXT_PUBLIC_POSTHOG_ID`.
+- **Google Analytics** — `NEXT_PUBLIC_GOOGLE_ID`.
+- **Giscus comments** — configured in `site.config.ts` (commented out).

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,127 @@
+# Caching & revalidation
+
+This site pulls content from the Notion API, which rate-limits to ~300 requests per 300 seconds per integration. Several layers keep us well under that ceiling. This doc walks through each layer top-down, from the CDN to the Notion API.
+
+## Layer 1 — Next.js ISR (the dominant cache)
+
+Notion pages are rendered by [`pages/[pageId].tsx`](../pages/[pageId].tsx) with `getStaticProps` + `revalidate: 86_400`.
+
+- Pages are statically generated at build time (see `getStaticPaths` → `getSiteMap()`).
+- After deploy, each page is served from Vercel's edge cache.
+- A page is re-rendered on-demand at most once per 24 hours per region, and only when someone requests it.
+- `fallback: true` means pages not in the sitemap can still be generated on first request.
+- Error responses use `revalidate: 10` so transient failures clear quickly.
+
+**Effect:** normal page traffic almost never hits Notion. Most of the other caches exist to keep the *revalidation path* fast and to protect the build/sitemap path.
+
+## Layer 2 — HTTP cache headers (CDN)
+
+Server-rendered routes set `Cache-Control` so Vercel's edge can absorb traffic without re-invoking the function.
+
+| Route | Header | Notes |
+|---|---|---|
+| [`pages/sitemap.xml.tsx`](../pages/sitemap.xml.tsx) | `public, max-age=28800, s-maxage=28800, stale-while-revalidate=28800` | 8h CDN cache. `s-maxage` is required for Vercel's CDN to cache — without it every crawler hit would rebuild the full sitemap. |
+| [`pages/feed.tsx`](../pages/feed.tsx) | `public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400` | 24h CDN cache for the RSS feed. |
+| [`pages/api/search-notion.ts`](../pages/api/search-notion.ts) | `public, s-maxage=300, max-age=60, stale-while-revalidate=3600` | 5min at CDN, 1h SWR. Tuned so repeated search queries don't hit Notion. |
+
+## Layer 3 — In-memory caches (per serverless instance)
+
+These live in Node memory inside a single Vercel serverless instance. They are cleared on cold start and do not sync across instances. They primarily help during ISR revalidation, sitemap generation, and warm-instance burst traffic.
+
+### `getPage` TTL cache — [`lib/notion.ts`](../lib/notion.ts)
+
+- TTL: **25 minutes**.
+- Keyed by `pageId`.
+- Caches the full `ExtendedRecordMap` after the AWS-URL fix, navigation merge, preview images, and tweet hydration.
+- Stores the in-flight `Promise` so concurrent requests for the same page share a single fetch (in-flight deduplication).
+- Rejected promises are evicted so errors aren't cached.
+
+### `search` TTL cache — [`lib/notion.ts`](../lib/notion.ts)
+
+- TTL: **60 seconds**.
+- Keyed by `JSON.stringify(params)`.
+- Same Promise-sharing behaviour as the page cache.
+
+### `getAllPages` / site map — [`lib/get-site-map.ts`](../lib/get-site-map.ts)
+
+- Wrapped in `pMemoize` (no TTL — lives for the lifetime of the process).
+- Cache key: `JSON.stringify([rootNotionPageId, rootNotionSpaceId, opts])`.
+- Called by `getStaticPaths`, `sitemap.xml`, and fallback URL resolution in `[pageId].tsx`.
+- A cold start rebuilds the entire map, which fans out to a `getPage` call per page — this is the most API-heavy operation in the codebase.
+
+### Navigation link pages — [`lib/notion.ts`](../lib/notion.ts)
+
+- Wrapped in `pMemoize` (no TTL).
+- Fetches the pages referenced by `navigationLinks` with minimal options (no collections, no missing blocks, no signed URLs).
+- Merged into every page record map when `navigationStyle !== 'default'`.
+
+### Client-side search cache — [`lib/search-notion.ts`](../lib/search-notion.ts)
+
+- Runs in the browser; wraps the `/api/search-notion` fetch.
+- Uses `pMemoize` with `ExpiryMap(10_000)` — 10s TTL keyed on query string.
+- Stops a user's keystroke-by-keystroke typing from sending duplicate requests.
+
+## Layer 4 — Redis (URI → pageId mappings, optional)
+
+[`lib/db.ts`](../lib/db.ts) wraps Keyv. Redis is controlled by `isRedisEnabled` in [`site.config.ts`](../site.config.ts). **Currently disabled.** With Redis off, Keyv falls back to an in-memory store — meaning the URI→pageId cache in [`lib/resolve-notion-page.ts`](../lib/resolve-notion-page.ts) is effectively per-instance and dies on cold start.
+
+What the Redis cache stores today:
+
+- `uri-to-page-id:<domain>:<env>:<normalized-uri>` → Notion `pageId`. No TTL.
+- Used by `resolveNotionPage` so we can skip the full site map lookup for known canonical paths.
+
+To enable Redis, set `isRedisEnabled: true` plus `REDIS_HOST`/`REDIS_PASSWORD` env vars. See [`.env.example`](../.env.example).
+
+## Layer 5 — Retry + rate-limit at the Notion client
+
+[`lib/notion-api.ts`](../lib/notion-api.ts) defines two `NotionAPI` subclasses.
+
+### `notion` — runtime client
+
+- Retries `429/502/503/504` **once** after a 1.1s delay.
+- Used by all runtime paths (ISR revalidation, API routes, `getPage`, `search`, RSS feed).
+- Short retry budget because runtime requests need to respond fast.
+
+### `buildNotion` — build-time client
+
+- Serializes every fetch through a Promise queue with a **1.1s minimum gap** → stays under 300 req / 300s.
+- Retries `429/5xx` up to **5 times** with exponential backoff (5s → 60s cap).
+- Used by `getAllPages` / `getSiteMap` during build and sitemap generation.
+
+## Request flow cheat sheet
+
+**A cached page view:**
+
+```
+User → Vercel CDN (ISR hit) → HTML
+```
+
+Zero Notion API calls.
+
+**An ISR revalidation after 24h:**
+
+```
+User → Vercel CDN (stale) → serverless fn
+  → resolveNotionPage
+    → db.get(uri-to-page-id)           [hit or miss]
+    → getPage(pageId)
+      → pageCache.get(pageId)          [hit = 0 API calls]
+      → notion.getPage(pageId)         [miss = 1 Notion call + retry policy]
+```
+
+**A sitemap.xml request (cache miss):**
+
+```
+Crawler → serverless fn
+  → getSiteMap()
+    → pMemoize hit                     [warm instance = 0 calls]
+    → getAllPagesInSpace               [cold = N Notion calls via buildNotion,
+                                         rate-limited to 1.1s each]
+```
+
+## Where to tune
+
+- **Staleness tolerance too low?** Drop `revalidate` in `[pageId].tsx` or the `PAGE_CACHE_TTL_MS` / `SEARCH_CACHE_TTL_MS` constants in `lib/notion.ts`.
+- **Hitting 429s during builds?** Increase `BUILD_MIN_FETCH_INTERVAL_MS` in `lib/notion-api.ts`.
+- **Want cross-instance persistence?** Enable Redis and extend `db` usage beyond URI mappings (e.g., wrap `getPage` with a Keyv-backed cache).
+- **Crawlers causing load?** Increase `s-maxage` on `sitemap.xml` / `feed.tsx`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,129 @@
+# Configuration
+
+The site pulls settings from two places:
+
+1. [`site.config.ts`](../site.config.ts) — hand-authored defaults (page IDs, domain, social handles, feature flags).
+2. Environment variables — secrets and deploy-specific values.
+
+Both are normalized and re-exported as typed values from [`lib/config.ts`](../lib/config.ts). Import from `lib/config.ts`, never from `site.config.ts` directly — the latter returns raw values without validation or type narrowing.
+
+## `site.config.ts` reference
+
+### Required
+
+| Field | Notes |
+|---|---|
+| `rootNotionPageId` | The Notion page served at `/`. Also the starting point for `getSiteMap()`. |
+| `name` | Display name. |
+| `domain` | Production domain (`wustep.me`). Used for canonical URLs, OG tags, etc. |
+| `author` | Author name used in OG meta and RSS feed. |
+
+### Recommended
+
+| Field | Notes |
+|---|---|
+| `rootNotionSpaceId` | Restricts all pages to one Notion workspace. Enforced by [`lib/acl.ts`](../lib/acl.ts). |
+| `description` | Used in OG tags and RSS description. |
+| `postsCollectionId` / `postsCollectionViewId` | Required for `/feed` to work. The view ID determines which posts are included and their order. |
+
+### Homepage Posts switcher
+
+A custom extension. The homepage has a "Posts" toggle that swaps between Gallery and List views.
+
+| Field | Notes |
+|---|---|
+| `homePostsCalloutBlockId` | Block above which the switcher UI is rendered. |
+| `homePostsHeadingBlockId` | Heading block that gets the switcher attached. |
+| `homeGalleryBlockIds` | Blocks shown in Gallery mode. |
+| `homeListBlockIds` | Blocks shown in List mode. |
+
+See the `usePostsViewMode` hook for how the state is persisted.
+
+### URL mapping
+
+| Field | Notes |
+|---|---|
+| `pageUrlOverrides` | Canonical clean URLs (bidirectional). See [routing.md](routing.md). |
+| `pageUrlAdditions` | One-way aliases for inbound redirects. |
+| `includeNotionIdInUrls` | Default: `true` in dev, `false` in prod. |
+
+### Navigation
+
+| Field | Notes |
+|---|---|
+| `navigationStyle` | `'default'` (Notion's breadcrumbs) or `'custom'`. |
+| `navigationLinks` | Custom nav entries (used when `navigationStyle === 'custom'`). |
+
+### Feature flags
+
+| Field | Default | Notes |
+|---|---|---|
+| `isPreviewImageSupportEnabled` | `false` | LQIP placeholders for all page images. See [images.md](images.md). |
+| `isSearchEnabled` | `true` | Currently `false` in this repo — search was disabled in 2024-11. |
+| `isRedisEnabled` | `false` | Enables Keyv+Redis for URI and preview image caches. |
+
+### Visual defaults
+
+| Field | Notes |
+|---|---|
+| `defaultPageIcon` | Fallback icon if a page has none. |
+| `defaultPageCover` | Fallback cover image. |
+| `defaultPageCoverPosition` | Vertical focal point (0–1) for covers. |
+
+### Social / integrations
+
+`x`, `github`, `linkedin`, `mastodon`, `youtube`, `newsletter`, `zhihu`, `giscus` — all optional. Giscus is configured as an object with repo/category/mapping fields; see the commented example in `site.config.ts`.
+
+## Environment variables
+
+Set in `.env.local` for development, Vercel project settings for production. All are optional unless noted.
+
+### Redis (only if `isRedisEnabled: true`)
+
+| Var | Notes |
+|---|---|
+| `REDIS_HOST` | Required. |
+| `REDIS_PASSWORD` | Required. |
+| `REDIS_USER` | Defaults to `default`. |
+| `REDIS_URL` | Overrides the auto-built URL if set. |
+| `REDIS_NAMESPACE` | Key prefix. Defaults to `preview-images`. |
+| `REDIS_ENABLED` | Alternative to the site-config flag. |
+
+### Analytics
+
+| Var | Notes |
+|---|---|
+| `NEXT_PUBLIC_FATHOM_ID` | Fathom site ID. |
+| `NEXT_PUBLIC_POSTHOG_ID` | PostHog project key. |
+| `NEXT_PUBLIC_GOOGLE_ID` | GA measurement ID. |
+
+### Misc
+
+| Var | Notes |
+|---|---|
+| `PORT` | Dev server port. Defaults to `3000`. |
+| `NOTION_API_BASE_URL` | Override the unofficial Notion API host. Rarely needed. |
+| `VERCEL_URL` | Auto-set by Vercel; used to build `apiHost` in preview deploys. |
+
+## Deriving values
+
+A few exports in `lib/config.ts` are computed from the above, not authored:
+
+- `environment` — `process.env.NODE_ENV` or `'development'`.
+- `isDev` — `true` when `NODE_ENV === 'development'`.
+- `isServer` — `typeof window === 'undefined'`.
+- `host` — `http://localhost:PORT` in dev, `https://<domain>` in prod.
+- `apiHost` — uses `VERCEL_URL` on preview deploys so API calls don't go to the production domain.
+- `site` — the subset of config passed around as `PageProps.site`.
+- `api.*` — absolute paths to API routes.
+- `inversePageUrlOverrides` — `pageId → URI` map for outbound link generation.
+
+## Validation
+
+`site.config.ts` is validated at import time:
+
+- `rootNotionPageId` must parse to a UUID; otherwise the import throws.
+- Every `pageUrlOverrides` / `pageUrlAdditions` URI must start with `/`.
+- Every mapped value must be a valid Notion page ID.
+
+If you add a new top-level URL mapping and the build fails early, check the error message from `cleanPageUrlMap` — it tells you which entry is bad.

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -1,0 +1,77 @@
+# Customizations
+
+This repo forks [nextjs-notion-starter-kit](https://github.com/transitive-bullshit/nextjs-notion-starter-kit) and adds a set of bespoke features. All local additions live under [`components/wustep/`](../components/wustep/) or as dedicated pages / lib files, making them easy to find and port.
+
+## Posts view switcher
+
+The homepage has a "Posts" heading with a toggle between **Gallery** and **List** views. The non-active view's blocks are hidden via CSS.
+
+- Config: `homePostsCalloutBlockId`, `homePostsHeadingBlockId`, `homeGalleryBlockIds`, `homeListBlockIds` in [`site.config.ts`](../site.config.ts).
+- UI component: [`components/wustep/PostsHeadingToggle.tsx`](../components/wustep/PostsHeadingToggle.tsx).
+- State persistence: [`lib/use-posts-view-mode.ts`](../lib/use-posts-view-mode.ts) — `localStorage` key `posts-view-mode`, default `list`.
+- The toggle is injected next to the configured heading block; the callout block above it is styled specially.
+
+## Applause button (footer)
+
+A per-page applause button in the footer using [applause-button.com](https://applause-button.com)'s free API.
+
+- Component: [`components/wustep/ApplauseButton.tsx`](../components/wustep/ApplauseButton.tsx).
+- Styles: [`styles/applause.css`](../styles/applause.css).
+- Picks a random notion-palette color per page for visual variety.
+- Counts are namespaced by the page's canonical URL.
+
+## Custom footer
+
+[`components/wustep/WustepFooter.tsx`](../components/wustep/WustepFooter.tsx) replaces the default footer with the applause button plus social links. Rendered from `NotionPage` instead of the upstream `Footer`.
+
+## Giscus comments
+
+GitHub Discussions-backed comments, opt-in via the `giscus` config field.
+
+- Component: [`components/wustep/Comments.tsx`](../components/wustep/Comments.tsx).
+- Loads giscus' client script dynamically; re-runs on dark-mode toggle so the embed's theme updates.
+- Theme files served from [`public/giscus/`](../public/giscus/).
+- Currently disabled (the `giscus` block in `site.config.ts` is commented out).
+
+## Button blocks
+
+A Notion-level extension: any highlighted block that's a link renders as a button. Implemented in the custom `blockMap` / styling passed to `react-notion-x`. See the NotionPage renderer and [`styles/wustep.css`](../styles/wustep.css) for the styling.
+
+## "Disable Collection Links" property
+
+A Notion page property that hides the collection view title on specific posts. Read in the NotionPage renderer and applied via CSS.
+
+## Posts collection / RSS feed
+
+[`pages/feed.tsx`](../pages/feed.tsx) builds an RSS feed directly from a Notion collection+view rather than from the site map, so post order follows the view's sort. Requires `postsCollectionId` and `postsCollectionViewId` in `site.config.ts`.
+
+## Playground
+
+A standalone section at `/playground` for interactive experiments — demos that don't fit the Notion-driven blog model.
+
+- Index: [`pages/playground/index.tsx`](../pages/playground/index.tsx) reads [`playground/registry.tsx`](../playground/registry.tsx) for the list.
+- Each entry has its own page under [`pages/playground/<slug>.tsx`](../pages/playground/).
+- Custom cover components: [`components/wustep/BookshelfCover.tsx`](../components/wustep/BookshelfCover.tsx), [`components/wustep/DominoCover.tsx`](../components/wustep/DominoCover.tsx).
+- Layout + nav: [`components/wustep/PlaygroundLayout.tsx`](../components/wustep/PlaygroundLayout.tsx), [`components/wustep/PlaygroundSidebar.tsx`](../components/wustep/PlaygroundSidebar.tsx).
+
+Playground pages are outside the Notion routing pipeline — they're ordinary Next.js pages. `getSiteMap` does not cover them; they ship via the default Next.js file-based routing.
+
+## Custom homepage
+
+[`pages/index.tsx`](../pages/index.tsx) renders [`components/AboutPage`](../components/AboutPage.tsx) instead of the Notion root page. The Notion root page is still reachable via its configured override URL (`/updates` in this repo).
+
+## Patches
+
+[`patches/notion-client@7.8.2.patch`](../patches/notion-client@7.8.2.patch) fixes a bug in `notion-client` where `recordMap.collection_view[viewId]?.value` would break on certain payload shapes — replaced with the safer `getBlockValue` helper. Applied automatically by pnpm on install.
+
+## Signed-URL fix
+
+The `.amazonaws.com` strip in [`lib/notion.ts`](../lib/notion.ts). Covered in detail in [images.md](images.md#signed-url-expiration-fix).
+
+## Social image generator
+
+Full custom OG image layout with author avatar, cover, title, and date. Edge runtime. See [images.md](images.md#social--og-images).
+
+## Shadcn/Radix UI kit
+
+[`components/ui/`](../components/ui/) holds a small set of shadcn-generated primitives (dialog, tooltip, switch, etc.) for use in playground demos and custom UI. Not used by the core Notion renderer.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,74 @@
+# Development
+
+Local setup, commands, and conventions.
+
+## Requirements
+
+- Node ≥ 20 (see `engines` in [`package.json`](../package.json))
+- `pnpm` 10 (see `packageManager` in `package.json` — enforced by Corepack)
+
+## Commands
+
+```bash
+pnpm dev                  # next dev (http://localhost:3000)
+pnpm build                # next build — crawls the site map via buildNotion
+pnpm start                # next start (serve the production build)
+pnpm deploy               # vercel deploy
+pnpm test                 # lint + prettier in parallel
+pnpm test:lint            # eslint
+pnpm test:prettier        # prettier --check
+```
+
+### Dependency-linking helpers
+
+For developing against a local checkout of `react-notion-x`:
+
+```bash
+pnpm deps:link            # pnpm link ../react-notion-x/packages/*
+pnpm deps:unlink          # reinstall from npm
+pnpm deps:upgrade         # pnpm up -L notion-client notion-types notion-utils react-notion-x
+```
+
+All three are no-ops in CI (`GITHUB_ACTIONS` guard).
+
+## `.env.local`
+
+Copy [`.env.example`](../.env.example) to `.env.local` for local overrides. Most values are optional; see [configuration.md](configuration.md) for the full list. Typical local setup needs nothing — the site just runs against the configured public Notion workspace.
+
+## Stack
+
+- **Next.js 16** (Pages Router, not App Router — the Notion rendering pipeline is built for `getStaticProps`)
+- **React 19**
+- **TypeScript 5.9**
+- **Tailwind CSS v4** + custom CSS files in [`styles/`](../styles/)
+- **`@fisch0920/config`** — shared ESLint + Prettier config
+- **pnpm patches** — see [`patches/`](../patches/) for local fixes applied on install
+
+## Code conventions
+
+- **Strict TypeScript.** `tsconfig.json` extends Next.js defaults; no `any` allowed in new code.
+- **Prettier** via `@fisch0920/config/prettier` — run on pre-commit via `lint-staged` + `simple-git-hooks`.
+- **ESLint flat config** in [`eslint.config.js`](../eslint.config.js).
+- **Path aliases:** `@/*` → project root (e.g., `@/lib/config`).
+- **CSS modules** for component-scoped styles (`*.module.css`), global sheets in [`styles/`](../styles/). See [styling.md](styling.md).
+
+## Git hooks
+
+`simple-git-hooks` runs `npx lint-staged` on pre-commit, which formats and lints staged `.ts`/`.tsx` files. Install the hook on first clone:
+
+```bash
+pnpm install
+npx simple-git-hooks
+```
+
+## Debugging tips
+
+- **Page not resolving?** Check `site.config.ts` → `pageUrlOverrides`, then whether the page is `Public` in Notion (public pages only; see `getSiteMap` filter).
+- **Stale images?** The `.amazonaws.com` strip in `getPage` should prevent this. If you see expired signed URLs, check that `lib/notion.ts` ran (vs. a direct `notion.getPage` call).
+- **429s in dev?** The runtime client only retries once. If you're hammering a lot of pages (crawling), either restart (to reset the in-memory caches) or temporarily use `buildNotion` which serializes requests.
+- **Build taking forever?** `buildNotion` enforces a 1.1s gap per fetch. For a site with N pages, expect at least `N × 1.1s` for site map construction.
+- **`NODE_ENV=development` with UUIDs in URLs:** `includeNotionIdInUrls` defaults to `true` in dev so you can round-trip any Notion URL locally. Toggle via `site.config.ts` if that's annoying.
+
+## Testing
+
+There's no unit-test suite. `pnpm test` runs linting and formatting only. Visual/integration testing is manual — push to a Vercel preview and click around.

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,100 @@
+# Images
+
+Three somewhat-tangled concerns: **preview images (LQIP)**, **social/OG images**, and the **signed-URL expiration fix**. Covered separately below.
+
+## Signed-URL expiration fix
+
+Notion serves user-uploaded images from S3 via short-lived signed URLs (`*.amazonaws.com`). If we cache a record map that contains these URLs, the URLs expire and images 404 until the next ISR revalidation.
+
+### Fix
+
+[`lib/notion.ts`](../lib/notion.ts) strips `.amazonaws.com` entries from `recordMap.signed_urls` after every `getPage` fetch:
+
+```ts
+if (recordMap && recordMap.signed_urls) {
+  const signedUrls = recordMap.signed_urls
+  const newSignedUrls: Record<string, string> = {}
+  for (const url in signedUrls) {
+    if (signedUrls[url] && signedUrls[url].includes('.amazonaws.com')) {
+      continue  // drop it
+    }
+    newSignedUrls[url] = signedUrls[url]!
+  }
+  recordMap.signed_urls = newSignedUrls
+}
+```
+
+`react-notion-x` then falls back to going through Notion's image proxy instead of the stale S3 URL. Credit to the upstream issue: [transitive-bullshit/nextjs-notion-starter-kit#279](https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/279#issuecomment-1245467818).
+
+## Preview images (LQIP)
+
+"LQIP" = Low-Quality Image Placeholder — a tiny blurred base64 data URI that's rendered instantly while the real image loads. Gives pages a smooth fade-in instead of a pop-in.
+
+### Flow
+
+1. `getPage` in [`lib/notion.ts`](../lib/notion.ts) calls `getPreviewImageMap(recordMap)` after fetching.
+2. [`lib/preview-images.ts`](../lib/preview-images.ts) collects every image URL referenced by the page (via `notion-utils`' `getPageImageUrls`).
+3. For each URL:
+   - Check Keyv (Redis if enabled, in-memory otherwise) using a normalized URL as the cache key.
+   - On miss: fetch the image bytes, run `lqip-modern` to produce `{ dataURIBase64, originalWidth, originalHeight }`, write to Keyv.
+4. The resulting `PreviewImageMap` is attached to `recordMap.preview_images` and passed into `react-notion-x`.
+
+Concurrency is limited to 8 at a time via `pMap`.
+
+### Gated by config
+
+Controlled by `isPreviewImageSupportEnabled` in [`site.config.ts`](../site.config.ts). When off, no preview images are generated and `recordMap.preview_images` stays undefined.
+
+### Cache key
+
+`normalizeUrl(url)` — strips query string and fragments so the same logical image always hits the same cache entry regardless of signed-URL variations.
+
+### Why Redis matters here
+
+LQIP generation is expensive: it downloads each image and runs a blur pipeline. Without Redis, the in-memory Keyv cache dies on every serverless cold start, so a cold instance regenerates preview images for every page it renders. With Redis, these survive across instances. The `REDIS_NAMESPACE` default of `preview-images` reflects this as the primary use case.
+
+## Social / OG images
+
+Dynamic Open Graph images generated per page via `next/og`.
+
+### Endpoint
+
+[`pages/api/social-image.tsx`](../pages/api/social-image.tsx) — runs on the Edge runtime.
+
+- `GET /api/social-image?id=<pageId>` returns a 1200×630 PNG.
+- Falls back to `rootNotionPageId` when no ID is passed.
+- Bundles Inter SemiBold as a font blob (`lib/fonts/inter-semibold`).
+
+### What it draws
+
+Layered composition:
+
+- Full-bleed cover image (from the page's `Social Image` property, falling back to `page_cover`, then `defaultPageCover`).
+- Centered white card with:
+  - Page title.
+  - "Detail" line — published date for posts, otherwise author or domain.
+- Top-left circular avatar (from the page's icon, falling back to `defaultPageIcon`).
+
+### Page metadata extraction
+
+`getNotionPageInfo()` pulls values out of the record map:
+
+- `title` — from `getBlockTitle`.
+- `image` — `Social Image` property → `page_cover` → `defaultPageCover`, checked for reachability with `ky.head` before use. Unsplash URLs get `?w=1200&fit=max` appended.
+- `authorImage` — block icon if it's a URL, else `defaultPageIcon`.
+- `date` — `Published` property, formatted as "Month YYYY" for posts only.
+- Enforces `rootNotionSpaceId` — refuses to render OG images for pages in other workspaces.
+
+### Where it's referenced
+
+- `getSocialImageUrl(pageId)` in [`lib/get-social-image-url.ts`](../lib/get-social-image-url.ts) builds the URL.
+- Used by `PageHead` for per-page OG tags.
+- Used by `pages/feed.tsx` for RSS `<enclosure>`.
+
+### Caching
+
+Edge responses are cached by Vercel's CDN by default. No explicit `Cache-Control` is set, so the function may re-run more often than necessary — consider adding `s-maxage` here if it shows up as a hot path.
+
+## Image URL mapping
+
+[`lib/map-image-url.ts`](../lib/map-image-url.ts) wraps `notion-utils`' `defaultMapImageUrl`, which rewrites Notion image URLs (signed S3, notion proxy, attachment paths) into stable, fetchable URLs. The only local addition is a passthrough for `defaultPageIcon` / `defaultPageCover` so those are never rewritten. Used by `getPreviewImageMap`, `getNotionPageInfo`, and `NotionPage`.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,96 @@
+# Routing
+
+How a URL like `/articles` or `/my-post-slug-2bc5cb08cf2c8036a1e3cddcb2c61d97` becomes a rendered Notion page.
+
+## Route structure
+
+- `/` — custom static homepage, [`pages/index.tsx`](../pages/index.tsx). Does not touch Notion.
+- `/[pageId]` — catch-all for every Notion page, [`pages/[pageId].tsx`](../pages/[pageId].tsx).
+- `/sitemap.xml`, `/feed`, `/robots.txt`, `/site`, `/404`, `/_error` — special pages.
+- `/api/search-notion`, `/api/social-image` — API routes.
+
+## Resolving `[pageId]` → recordMap
+
+Logic lives in [`lib/resolve-notion-page.ts`](../lib/resolve-notion-page.ts). For a request to `/<rawPageId>`:
+
+```
+1. Normalize the raw path
+   normalizePageIdPath()              ← strips dashes from trailing UUID
+       "foo-2bc5cb08-cf2c-8036-..."  →  "foo-2bc5cb08cf2c8036..."
+
+2. Try to extract a UUID directly from the path
+   parsePageId(normalizedRawPageId)
+
+3. If no UUID, check manual overrides
+   pageUrlOverrides[rawPath]          ← from site.config.ts
+   pageUrlAdditions[rawPath]
+
+4. If still no UUID, check the Redis URI cache
+   db.get("uri-to-page-id:<domain>:<env>:<path>")
+
+5. If still no UUID, fall back to the site map
+   getSiteMap().canonicalPageMap[rawPath]
+   — on hit, write result back to Redis for step 4 next time
+
+6. If resolved, fetch
+   getPage(pageId) → ExtendedRecordMap
+
+7. Run ACL check (lib/acl.ts) to reject pages from other workspaces
+```
+
+If nothing resolves, return a 404. 404 lookups are intentionally **not** cached so newly-added pages appear without waiting for a TTL.
+
+## `pageUrlOverrides` vs. `pageUrlAdditions`
+
+Both live in `site.config.ts` and are processed by [`lib/config.ts`](../lib/config.ts):
+
+- **`pageUrlOverrides`** — canonical, bidirectional. `/articles → <uuid>` means `/articles` resolves to that page **and** that page's outbound links render as `/articles`. Used for the "clean" URLs of top-level sections.
+- **`pageUrlAdditions`** — one-way alias. `/old-post → <uuid>` resolves inbound but does not change how the page URL is displayed elsewhere. Useful for redirects.
+
+Example from [`site.config.ts`](../site.config.ts):
+
+```ts
+pageUrlOverrides: {
+  '/articles': 'e40efc6731ea4e1da2626d709950fbe4',
+  '/notes':    'a9d2669020314160b70110639617e822',
+  '/projects': '511994667bac45fda9fd8f9db136e476',
+  // ...
+}
+```
+
+## Canonical slug generation
+
+For pages *not* in `pageUrlOverrides`, the URL is built from the Notion page title by [`lib/get-canonical-page-id.ts`](../lib/get-canonical-page-id.ts) → `notion-utils`' `getCanonicalPageId`. In production this produces slugs like `my-post-title` (no UUID). In dev, `includeNotionIdInUrls` appends the UUID for easier debugging.
+
+The outbound URL mapper lives in [`lib/map-page-url.ts`](../lib/map-page-url.ts) and is handed to `react-notion-x` via `NotionPage` so internal links render correctly.
+
+## Static path generation
+
+`getStaticPaths` in [`pages/[pageId].tsx`](../pages/[pageId].tsx) builds the full set of paths to pre-render:
+
+```ts
+const siteMap = await getSiteMap()
+const allPageIds = [
+  ...new Set([
+    ...Object.keys(siteMap.canonicalPageMap),  // every public page
+    ...Object.keys(pageUrlOverrides)           // + manual overrides
+  ])
+]
+```
+
+- `fallback: true` — paths outside this set still work; they're rendered on first request and cached from then on.
+- In dev, `paths: []` with `fallback: true` skips the upfront crawl.
+
+## Site map construction
+
+[`lib/get-site-map.ts`](../lib/get-site-map.ts) calls `notion-utils`' `getAllPagesInSpace`, which walks from `rootNotionPageId` outward, following links and collections up to `maxDepth: 1`. For each discovered page:
+
+- Skip if the page's `Public` property is `false`.
+- Compute a canonical ID and insert into `canonicalPageMap`.
+- Warn (and skip the duplicate) if two pages collide on canonical ID.
+
+This is the most API-heavy operation in the codebase — one `getPage` per discovered page, all serialized through the build-time rate limiter.
+
+## Workspace scoping
+
+[`lib/acl.ts`](../lib/acl.ts) rejects pages whose `space_id` doesn't match `rootNotionSpaceId`. This prevents someone from crafting a URL that loads an unrelated Notion page (e.g. from someone else's public workspace) through this site's domain.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,0 +1,67 @@
+# Styling
+
+The styling story is deliberately two-track: the Notion-rendered content uses plain CSS sheets from the upstream starter kit, while the playground and newer custom UI uses Tailwind v4 + shadcn. Migration between the two is incremental.
+
+## CSS file map
+
+| File | Purpose |
+|---|---|
+| [`styles/globals.css`](../styles/globals.css) | Tailwind v4 import, shadcn tokens, baseline typography. Loaded globally. |
+| [`styles/notion.css`](../styles/notion.css) | Upstream overrides for `react-notion-x` — padding, code blocks, image framing, etc. |
+| [`styles/wustep.css`](../styles/wustep.css) | The bulk of this site's custom Notion styling — colors, dark-mode tokens, button-block styling, posts switcher, callouts, footer. |
+| [`styles/prism-theme.css`](../styles/prism-theme.css) | Syntax highlighting theme for code blocks. |
+| [`styles/applause.css`](../styles/applause.css) | Styles for the applause button. |
+
+All five are imported from `pages/_app.tsx` or via `_document.tsx`.
+
+## Tailwind v4
+
+Configured by [`postcss.config.js`](../postcss.config.js) using `@tailwindcss/postcss`. No `tailwind.config.js` — v4 uses CSS-native `@custom-variant` / `@theme` directives inside `globals.css`.
+
+- Dark mode: `@custom-variant dark (&:is(.dark *))` — toggled by a `dark` class on the root element.
+- The shadcn token system (`--background`, `--foreground`, etc.) sits in `:root` in `globals.css`.
+
+## The two overlapping token systems
+
+There's a design-system overlap worth knowing about:
+
+- `styles/wustep.css` `:root` — `--primary`, `--secondary`, `--accent`, `--background`, etc. Used by the Notion page and custom components (AboutPage, WustepFooter, etc.).
+- `styles/globals.css` `:root` — shadcn/Tailwind tokens for the UI kit in [`components/ui/`](../components/ui/).
+
+They don't conflict because they cover mostly disjoint component sets, but new components should pick a track and stick with it.
+
+## Dark mode
+
+Driven by [`lib/use-dark-mode.ts`](../lib/use-dark-mode.ts) (a thin wrapper around `@fisch0920/use-dark-mode`). Toggles a `dark-mode` class on `<body>`. `styles/wustep.css` has `.dark-mode { --primary: ...; ... }` blocks that swap the token values.
+
+The shadcn side uses the `dark` class variant — separate mechanism.
+
+## CSS modules
+
+Per-component scoped styles live alongside their component:
+
+- [`components/AboutPage.module.css`](../components/AboutPage.module.css)
+- [`components/PageSocial.module.css`](../components/PageSocial.module.css)
+- [`components/Page404.module.css`](../components/Page404.module.css)
+- [`components/styles.module.css`](../components/styles.module.css) — shared across the Notion page shell.
+- [`components/wustep/BookshelfCover.module.css`](../components/wustep/BookshelfCover.module.css)
+
+Any new UI component should follow this pattern rather than adding to the global sheets, unless it's overriding `react-notion-x` output specifically.
+
+## Fonts
+
+Loaded via `next/font/google` in [`pages/_app.tsx`](../pages/_app.tsx). The OG image generator separately bundles Inter SemiBold as a binary blob in [`lib/fonts/`](../lib/fonts/) because Edge runtime can't read network fonts at request time.
+
+## Notion-specific styling notes
+
+A few patterns used throughout `styles/wustep.css`:
+
+- Target block types via `.notion-callout.notion-<color>_background` for callout colors.
+- Target button blocks (highlighted link blocks) via the classes `react-notion-x` emits plus extra markers added in the custom `blockMap`.
+- Collection titles can be hidden on a per-page basis via the `Disable Collection Links` property; the styling is applied via a conditional class on the page root.
+
+## When to use which
+
+- Styling a Notion block or the page shell → `styles/wustep.css`.
+- Styling a custom component (AboutPage, playground pages, etc.) → a CSS module colocated with the component.
+- Styling a shadcn-based UI primitive → Tailwind classes + the token system in `globals.css`.

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -16,6 +16,36 @@ import { getTweetsMap } from './get-tweets'
 import { notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
 
+const PAGE_CACHE_TTL_MS = 25 * 60 * 1000
+const SEARCH_CACHE_TTL_MS = 60 * 1000
+
+type CacheEntry<T> = { value: Promise<T>; expiresAt: number }
+
+function createTTLCache<T>(ttlMs: number) {
+  const store = new Map<string, CacheEntry<T>>()
+  return {
+    get(key: string): Promise<T> | undefined {
+      const entry = store.get(key)
+      if (!entry) return undefined
+      if (entry.expiresAt <= Date.now()) {
+        store.delete(key)
+        return undefined
+      }
+      return entry.value
+    },
+    set(key: string, value: Promise<T>) {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs })
+      // evict on rejection so we don't cache errors
+      value.catch(() => {
+        if (store.get(key)?.value === value) store.delete(key)
+      })
+    }
+  }
+}
+
+const pageCache = createTTLCache<ExtendedRecordMap>(PAGE_CACHE_TTL_MS)
+const searchCache = createTTLCache<SearchResults>(SEARCH_CACHE_TTL_MS)
+
 const getNavigationLinkPages = pMemoize(
   async (): Promise<ExtendedRecordMap[]> => {
     const navigationLinkPageIds = (navigationLinks || [])
@@ -43,6 +73,15 @@ const getNavigationLinkPages = pMemoize(
 )
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
+  const cached = pageCache.get(pageId)
+  if (cached) return cached
+
+  const promise = getPageUncached(pageId)
+  pageCache.set(pageId, promise)
+  return promise
+}
+
+async function getPageUncached(pageId: string): Promise<ExtendedRecordMap> {
   let recordMap = await notion.getPage(pageId)
   /**
    * @wustep: fix for expiring images by removing signed AWS urls
@@ -86,5 +125,11 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
 }
 
 export async function search(params: SearchParams): Promise<SearchResults> {
-  return notion.search(params)
+  const key = JSON.stringify(params)
+  const cached = searchCache.get(key)
+  if (cached) return cached
+
+  const promise = notion.search(params)
+  searchCache.set(key, promise)
+  return promise
 }

--- a/pages/api/search-notion.ts
+++ b/pages/api/search-notion.ts
@@ -19,7 +19,7 @@ export default async function searchNotion(
 
   res.setHeader(
     'Cache-Control',
-    'public, s-maxage=60, max-age=60, stale-while-revalidate=60'
+    'public, s-maxage=300, max-age=60, stale-while-revalidate=3600'
   )
   res.status(200).json(results)
 }

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   // cache for up to 8 hours
   res.setHeader(
     'Cache-Control',
-    'public, max-age=28800, stale-while-revalidate=28800'
+    'public, max-age=28800, s-maxage=28800, stale-while-revalidate=28800'
   )
   res.setHeader('Content-Type', 'text/xml')
   res.write(createSitemap(siteMap))


### PR DESCRIPTION
## Summary

- **Caching**: add in-memory TTL caches around `getPage` (25min) and `search` (60s) in `lib/notion.ts` so repeated requests on a warm serverless instance (and ISR revalidations) don't re-hit Notion. Caches the Promise so concurrent requests for the same pageId dedupe into a single fetch. Rejected promises auto-evict so errors aren't cached.
- **CDN headers**: add `s-maxage=28800` to `sitemap.xml` (without it Vercel's CDN wasn't caching the sitemap, so crawlers could trigger full site-map rebuilds). Bump `/api/search-notion` `s-maxage` 60→300 and `stale-while-revalidate` 60→3600.
- **Docs**: new `docs/` folder covering architecture, routing, configuration, caching, images, development, styling, and customizations — each linked from `docs/README.md` and cross-referencing the relevant source files.

## Why

The site is rate-limited by Notion's unofficial API (~300 req / 300s). Most traffic is absorbed by Next.js ISR (24h revalidate), but revalidations, sitemap generation, and `fallback: true` paths still hit Notion directly. These caches reduce that load without requiring Redis.

## Tradeoffs

- The in-memory cache is per-instance — cold starts still pay a fresh fetch. For cross-instance persistence we'd need Redis (currently disabled in `site.config.ts`).
- 25min TTL on `getPage` means edits can take up to 25min to show during an ISR revalidation window, but warm instances on Vercel rarely live that long anyway so the practical staleness is usually shorter.

## Test plan

- [ ] `pnpm build` completes without errors
- [ ] `pnpm test` (lint + prettier) passes
- [ ] Deploy to preview; verify pages still render
- [ ] Hit `/sitemap.xml` twice and confirm second response has `x-vercel-cache: HIT`
- [ ] Spot-check a Notion page loads and images aren't broken (signed-URL fix still in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)