### PR TITLE
Fix Vercel build: use pnpm 10 via corepack

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack enable && pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Problem

Vercel builds were failing during install with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "patchedDependencies" configuration doesn't match the value found in the lockfile
```

Root cause from the build log:

```
Detected pnpm-lock.yaml 9 which may be generated by pnpm@9.x or pnpm@10.x
Using pnpm@9.x based on project creation date
```

This repo uses **pnpm 10** (`packageManager: pnpm@10.12.1`), where `patchedDependencies` (the `notion-client@7.8.2` patch) lives in `pnpm-workspace.yaml`. But Vercel was building with **pnpm 9**, which only reads `patchedDependencies` from `package.json`. Seeing none there while the lockfile declared one, pnpm 9 aborted the frozen install.

## Fix

Added `vercel.json` with an install command that enables corepack:

```json
{
  "installCommand": "corepack enable && pnpm install --frozen-lockfile"
}
```

`corepack enable` makes Vercel honor the `packageManager` field and run pnpm 10.12.1, matching local dev.

## Verification

Confirmed locally that `pnpm install --frozen-lockfile` passes cleanly with pnpm 10.12.1 — the lockfile was never out of sync, the issue was purely the pnpm version Vercel selected.

https://claude.ai/code/session_01Pw3CU5f9UoWUKbnYXpdrHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw3CU5f9UoWUKbnYXpdrHs)_