### PR TITLE
Fix Vercel build: pin pnpm 10.12.1 via npx

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "corepack enable && pnpm install --frozen-lockfile"
+  "installCommand": "npx --yes pnpm@10.12.1 install --frozen-lockfile"
 }


### PR DESCRIPTION
## Follow-up to #16

The previous fix used `corepack enable && pnpm install`, but Vercel still built with pnpm 9 and hit the same `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. `corepack enable` only installs shims — it does **not** override Vercel's pre-installed pnpm 9, which still won the PATH lookup.

## Fix

Invoke pnpm 10.12.1 directly via npx, making the version deterministic regardless of PATH:

```json
{
  "installCommand": "npx --yes pnpm@10.12.1 install --frozen-lockfile"
}
```

pnpm 10 reads `patchedDependencies` from `pnpm-workspace.yaml` (where this repo correctly has it), so the frozen install matches the lockfile.

## Verification

- `npx --yes pnpm@10.12.1 --version` → `10.12.1`
- `pnpm install --frozen-lockfile` passes cleanly under pnpm 10.12.1

https://claude.ai/code/session_01Pw3CU5f9UoWUKbnYXpdrHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw3CU5f9UoWUKbnYXpdrHs)_