### PR TITLE
UI/UX improvements: 20 accepted ideas from /propose-improvements (2026-07-11)

### DIFF
--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -405,7 +405,7 @@ a.bioHint {
   transform: scale(0.86) rotate(-6deg);
   transition:
     opacity 180ms ease-out,
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 220ms var(--ease-out-smooth),
     color 180ms ease,
     background-color 180ms ease;
 }

--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -4,11 +4,20 @@
   background: var(--about-bg);
   color: var(--about-text);
   font-family: var(--font-serif);
-  opacity: 0;
+  /* CSS-only entrance so server-rendered content never waits on hydration */
+  animation: pageFadeIn 600ms ease;
   transition:
-    opacity 600ms ease,
     background-color 300ms ease,
     color 300ms ease;
+}
+
+@keyframes pageFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .page.dark {
@@ -31,10 +40,6 @@
   --about-border-hover: rgba(0, 0, 0, 0.15);
   --about-card: rgba(0, 0, 0, 0.03);
   --about-card-hover: rgba(0, 0, 0, 0.06);
-}
-
-.page.visible {
-  opacity: 1;
 }
 
 .glow {

--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -112,6 +112,7 @@
 /* Container-level overrides; the shared ThemeToggle provides reset,
  * rotation, and yellow/indigo hover colors. */
 .themeToggle {
+  position: relative;
   width: 40px;
   height: 40px;
   border-radius: 12px;
@@ -170,6 +171,7 @@
 }
 
 .navIcon {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -184,6 +186,15 @@
     background-color 180ms ease,
     border-color 180ms ease,
     color 180ms ease;
+}
+
+/* 44px hit area via pseudo-element — visual size stays 40px. */
+.navIcon::after,
+.themeToggle::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
 }
 
 .navIcon svg {

--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -1,6 +1,7 @@
 .page {
   position: relative;
-  min-height: 100vh;
+  min-height: 100vh; /* fallback for browsers without dvh */
+  min-height: 100dvh;
   background: var(--about-bg);
   color: var(--about-text);
   font-family: var(--font-serif);

--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -275,6 +275,12 @@ a.bioHint {
   cursor: pointer;
 }
 
+.bioHint:focus-visible {
+  outline: 2px solid var(--about-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 @media (hover: hover) {
   .bioHint:hover {
     text-decoration-color: var(--about-accent);
@@ -1156,7 +1162,9 @@ a.bioHint {
   text-align: center;
 }
 
-.tooltipWrapperInline:focus-within .tooltip {
+/* Keyboard parity with the hover reveal below — any focused trigger
+   (link or focusable span) shows its tooltip. */
+.tooltipWrapper:focus-within .tooltip {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }

--- a/components/AboutPage.tsx
+++ b/components/AboutPage.tsx
@@ -85,15 +85,6 @@ const writingPersonal = [
   }
 ]
 
-function useAnimateIn() {
-  const [visible, setVisible] = React.useState(false)
-  React.useEffect(() => {
-    const id = requestAnimationFrame(() => setVisible(true))
-    return () => cancelAnimationFrame(id)
-  }, [])
-  return visible
-}
-
 function Tooltip({
   children,
   label,
@@ -137,7 +128,6 @@ function Tooltip({
 }
 
 export function AboutPage() {
-  const animateIn = useAnimateIn()
   const [isDark, setIsDark] = React.useState(true)
 
   React.useEffect(() => {
@@ -152,9 +142,7 @@ export function AboutPage() {
   }, [isDark])
 
   return (
-    <main
-      className={`${styles.page} ${animateIn ? styles.visible : ''} ${isDark ? styles.dark : styles.light}`}
-    >
+    <main className={`${styles.page} ${isDark ? styles.dark : styles.light}`}>
       <div className={styles.glow} aria-hidden='true' />
 
       <div className={styles.container}>

--- a/components/AboutPage.tsx
+++ b/components/AboutPage.tsx
@@ -97,6 +97,7 @@ function Tooltip({
   inline?: boolean
 }) {
   const wrapperRef = React.useRef<HTMLSpanElement>(null)
+  const tooltipId = React.useId()
   const [position, setPosition] = React.useState<'above' | 'below'>(
     forcedPosition ?? 'below'
   )
@@ -110,15 +111,33 @@ function Tooltip({
     setPosition(spaceBelow >= tooltipHeight ? 'below' : 'above')
   }, [forcedPosition])
 
+  // Describe the trigger with the tooltip and make plain-span triggers
+  // focusable so keyboard users can reveal it via :focus-within.
+  const child = React.Children.only(children)
+  const trigger = React.isValidElement(child)
+    ? React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+        'aria-describedby': tooltipId,
+        ...(child.type === 'span' ? { tabIndex: 0 } : null)
+      })
+    : children
+
   return (
     <span
       ref={wrapperRef}
       className={`${styles.tooltipWrapper} ${inline ? styles.tooltipWrapperInline : ''}`}
       onMouseEnter={updatePosition}
       onFocus={updatePosition}
+      onKeyDown={(event) => {
+        // WCAG 1.4.13: let keyboard users dismiss the tooltip in place.
+        if (event.key === 'Escape' && document.activeElement) {
+          ;(document.activeElement as HTMLElement).blur()
+        }
+      }}
     >
-      {children}
+      {trigger}
       <span
+        id={tooltipId}
+        role='tooltip'
         className={`${styles.tooltip} ${position === 'above' ? styles.tooltipAbove : styles.tooltipBelow}`}
       >
         {label}

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -3,10 +3,11 @@ import * as config from '@/lib/config'
 import styles from './Page404.module.css'
 import { PageHead } from './PageHead'
 
-export function ErrorPage({ statusCode }: { statusCode: number }) {
-  const title = `Error ${statusCode}`
+export function ErrorPage({ statusCode }: { statusCode?: number }) {
+  const code = statusCode ?? 500
+  const title = `Error ${code}`
   const description =
-    statusCode === 500
+    code === 500
       ? "Something went wrong on our end. We're looking into it."
       : 'An unexpected error occurred. Please try again later.'
 
@@ -16,7 +17,7 @@ export function ErrorPage({ statusCode }: { statusCode: number }) {
 
       <div className={styles.page}>
         <div className={styles.content}>
-          <p className={styles.code}>{statusCode}</p>
+          <p className={styles.code}>{code}</p>
 
           <div className={styles.divider} />
 

--- a/components/LoadingIcon.tsx
+++ b/components/LoadingIcon.tsx
@@ -20,12 +20,9 @@ export function LoadingIcon(props: ComponentPropsWithoutRef<'svg'>) {
           y2='17.7832031%'
           id='linearGradient-1'
         >
-          <stop stopColor='rgba(164, 164, 164, 1)' offset='0%' />
-          <stop
-            stopColor='rgba(164, 164, 164, 0)'
-            stopOpacity='0'
-            offset='100%'
-          />
+          {/* currentColor lets the CSS color token theme the spinner. */}
+          <stop stopColor='currentColor' offset='0%' />
+          <stop stopColor='currentColor' stopOpacity='0' offset='100%' />
         </linearGradient>
       </defs>
 
@@ -43,12 +40,12 @@ export function LoadingIcon(props: ComponentPropsWithoutRef<'svg'>) {
             <path
               d='M10,2 C4.4771525,2 0,6.4771525 0,12'
               id='Oval-2'
-              stroke='rgba(164, 164, 164, 1)'
+              stroke='currentColor'
               strokeWidth='4'
             />
             <rect
               id='Rectangle-1'
-              fill='rgba(164, 164, 164, 1)'
+              fill='currentColor'
               x='8'
               y='0'
               width='4'

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -35,6 +35,7 @@ import { ErrorPage } from './ErrorPage'
 import { Footer } from './Footer'
 import { Loading } from './Loading'
 import { NotionPageHeader } from './NotionPageHeader'
+import { NotionPageSkeleton } from './NotionPageSkeleton'
 import { Page404 } from './Page404'
 import { PageAside } from './PageAside'
 import { PageHead } from './PageHead'
@@ -346,7 +347,7 @@ export function NotionPage({
   }, [notionFallbackUrl, pageId])
 
   if (router.isFallback) {
-    return <Loading />
+    return <NotionPageSkeleton />
   }
 
   if (externalRedirectUrl || notionFallbackUrl) {

--- a/components/NotionPageSkeleton.module.css
+++ b/components/NotionPageSkeleton.module.css
@@ -1,0 +1,65 @@
+.page {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: var(--w-background);
+  color: var(--w-primary);
+}
+
+/* Mirrors the Notion article column so the swap to real content is calm. */
+.column {
+  width: min(708px, calc(100vw - 48px));
+  margin: 0 auto;
+  padding-top: 96px;
+}
+
+.icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  margin-bottom: 24px;
+}
+
+.title {
+  height: 38px;
+  width: 65%;
+  border-radius: 8px;
+  margin-bottom: 14px;
+}
+
+.meta {
+  height: 14px;
+  width: 30%;
+  border-radius: 6px;
+  margin-bottom: 28px;
+}
+
+.divider {
+  height: 1px;
+  background: var(--w-divider);
+  margin-bottom: 28px;
+}
+
+.line {
+  height: 14px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.icon,
+.title,
+.meta,
+.line {
+  background: var(--w-surface-hover);
+  animation: skeletonPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes skeletonPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}

--- a/components/NotionPageSkeleton.tsx
+++ b/components/NotionPageSkeleton.tsx
@@ -1,0 +1,24 @@
+import styles from './NotionPageSkeleton.module.css'
+
+const LINE_WIDTHS = [92, 100, 97, 88, 100, 62]
+
+/**
+ * Article-shaped placeholder shown while ISR generates an uncached Notion
+ * page. Uses the wustep (--w-*) tokens so it is dark-mode aware; the global
+ * prefers-reduced-motion rule freezes the pulse.
+ */
+export function NotionPageSkeleton() {
+  return (
+    <div className={styles.page} role='status' aria-label='Loading page'>
+      <div className={styles.column}>
+        <div className={styles.icon} />
+        <div className={styles.title} />
+        <div className={styles.meta} />
+        <div className={styles.divider} />
+        {LINE_WIDTHS.map((width, i) => (
+          <div key={i} className={styles.line} style={{ width: `${width}%` }} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/Page404.module.css
+++ b/components/Page404.module.css
@@ -4,8 +4,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: var(--background);
-  color: var(--primary);
+  background: var(--w-background);
+  color: var(--w-primary);
   font-family: var(--font-sans);
   overflow: hidden;
 }
@@ -37,7 +37,7 @@
   letter-spacing: 0.08em;
   line-height: 1;
   margin: 0;
-  color: var(--primary);
+  color: var(--w-primary);
   opacity: 0.12;
   user-select: none;
   animation: fadeIn 1000ms var(--ease-out-quart) both;
@@ -46,7 +46,7 @@
 .divider {
   width: 48px;
   height: 1px;
-  background: var(--divider);
+  background: var(--w-divider);
   margin: 1.5rem 0;
   animation: expandLine 800ms var(--ease-out-quart) 200ms both;
 }
@@ -72,7 +72,7 @@
 }
 
 .description {
-  color: var(--secondary);
+  color: var(--w-secondary);
   font-size: 0.95rem;
   line-height: 1.6;
   margin: 0 0 2rem;
@@ -87,10 +87,10 @@
   font-family: var(--font-sans);
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--secondary);
+  color: var(--w-secondary);
   text-decoration: none;
   padding: 10px 20px;
-  border: 1px solid var(--divider);
+  border: 1px solid var(--w-divider);
   border-radius: 100px;
   transition:
     color 200ms ease,
@@ -100,9 +100,9 @@
 }
 
 .homeLink:hover {
-  color: var(--primary);
-  border-color: var(--divider-hover);
-  background: var(--surface);
+  color: var(--w-primary);
+  border-color: var(--w-divider-hover);
+  background: var(--w-surface);
 }
 
 .homeLink svg {
@@ -118,10 +118,10 @@
 .devError {
   margin-top: 1.5rem;
   padding: 1rem;
-  background: var(--surface);
+  background: var(--w-surface);
   border-radius: var(--radius-md);
   font-size: 0.8rem;
-  color: var(--secondary);
+  color: var(--w-secondary);
   max-width: 400px;
   font-family: monospace;
   animation: fadeIn 800ms var(--ease-out-quart) 600ms both;

--- a/components/PageSocial.module.css
+++ b/components/PageSocial.module.css
@@ -50,13 +50,14 @@
   margin-top: 3px;
 }
 
+/* Full-size circle scaled to 0 and grown on hover — transform is
+   GPU-composited, unlike the width/height animation it replaces. */
 .actionBgPane {
-  transition:
-    width 300ms ease-out,
-    height 300ms ease-out;
+  transition: transform 300ms ease-out;
   border-radius: 50%;
-  width: 0;
-  height: 0;
+  width: 100%;
+  height: 100%;
+  transform: scale(0);
 }
 
 .action svg {
@@ -71,15 +72,14 @@
 
 @media (hover: hover) {
   .action:hover .actionBgPane {
-    width: 100%;
-    height: 100%;
-    transition:
-      width 100ms ease-out,
-      height 100ms ease-out;
+    transform: scale(1);
+    transition: transform 100ms ease-out;
   }
 
   .action:hover svg {
     transition: color 100ms ease-out;
+    /* Deliberate constant: white icon over the brand-colored pane
+       (dark mode overrides to --fg-color below). */
     color: #ffffff;
   }
 

--- a/components/design/DesignWorkbench.module.css
+++ b/components/design/DesignWorkbench.module.css
@@ -140,7 +140,7 @@
   grid-template-columns: 352px minmax(0, 1fr);
   height: calc(100dvh - 52px);
   overflow: hidden;
-  transition: grid-template-columns 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: grid-template-columns 220ms var(--ease-out-smooth);
 }
 
 .panelClosed {
@@ -157,8 +157,8 @@
   border-right: 1px solid #11120f;
   background: var(--dw-panel);
   transition:
-    width 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+    width 220ms var(--ease-out-smooth),
+    transform 220ms var(--ease-out-smooth);
 }
 
 .panelClosed .panel {

--- a/components/design/DesignWorkbench.module.css
+++ b/components/design/DesignWorkbench.module.css
@@ -223,7 +223,7 @@
   flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
-  scrollbar-color: #b4b5b0 transparent;
+  scrollbar-color: var(--dw-scrollbar-thumb) transparent;
   scrollbar-width: thin;
 }
 

--- a/components/styles.module.css
+++ b/components/styles.module.css
@@ -23,10 +23,10 @@
    * font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
    * 'Apple Color Emoji', Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol';
    * background-color: var(--bg-color); */
-  color: var(--primary);
-  caret-color: var(--primary);
+  color: var(--w-primary);
+  caret-color: var(--w-primary);
   font-family: var(--font-sans);
-  background: var(--background);
+  background: var(--w-background);
 }
 
 .loadingIcon {

--- a/components/styles.module.css
+++ b/components/styles.module.css
@@ -34,7 +34,8 @@
   display: block;
   width: 24px;
   height: 24px;
-  color: rgba(55, 53, 47, 0.4);
+  /* Theme-aware: the SVG strokes/fills use currentColor. */
+  color: var(--w-secondary);
 }
 
 .main {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -274,7 +274,11 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar='trigger'
       variant='ghost'
       size='icon'
-      className={cn('h-7 w-7', className)}
+      // 44px hit area via ::after — the visible button stays 28px.
+      className={cn(
+        'relative h-7 w-7 after:absolute after:-inset-2',
+        className
+      )}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()

--- a/components/wustep/DesignButton.module.css
+++ b/components/wustep/DesignButton.module.css
@@ -22,7 +22,7 @@
   }
 
   .designButton:hover svg {
-    animation: design-tool-nudge 480ms cubic-bezier(0.22, 1, 0.36, 1);
+    animation: design-tool-nudge 480ms var(--ease-out-smooth);
   }
 }
 

--- a/components/wustep/LensesIllustrationLabCover.module.css
+++ b/components/wustep/LensesIllustrationLabCover.module.css
@@ -136,7 +136,7 @@
 .panelHeader span {
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: #a97824;
 }
 

--- a/components/wustep/MidiVisualizer.module.css
+++ b/components/wustep/MidiVisualizer.module.css
@@ -8,7 +8,7 @@
   /* Mirror midi.to's CSS variables for direct visual parity. */
   --piano-height: clamp(110px, 14vh, 160px);
   --transport-height: 56px;
-  --primary: #00d4b1;
+  --w-primary: #00d4b1;
   --primary-soft: rgba(0, 212, 177, 0.16);
   --primary-glow: rgba(0, 212, 177, 0.4);
   --primary-dark: #018470;
@@ -84,7 +84,7 @@
   gap: 6px;
   background: var(--primary-soft);
   border: 1px solid rgba(0, 212, 177, 0.35);
-  color: var(--primary);
+  color: var(--w-primary);
   border-radius: 4px;
   padding: 4px 10px;
   font-size: 0.7rem;
@@ -150,7 +150,7 @@
 
 .trackItemActive {
   background: rgba(0, 212, 177, 0.08);
-  border-left-color: var(--primary);
+  border-left-color: var(--w-primary);
 }
 
 .trackItemActive:hover {
@@ -273,12 +273,12 @@
 .midiPillActive {
   background: var(--primary-soft);
   border-color: rgba(0, 212, 177, 0.4);
-  color: var(--primary);
+  color: var(--w-primary);
 }
 
 .midiPillActive:hover {
   background: rgba(0, 212, 177, 0.22);
-  color: var(--primary);
+  color: var(--w-primary);
 }
 
 .midiDot {
@@ -289,7 +289,7 @@
 }
 
 .midiDotActive {
-  background: var(--primary);
+  background: var(--w-primary);
   box-shadow: 0 0 6px var(--primary-glow);
 }
 
@@ -330,7 +330,7 @@
   /* While pressed: rounded at the top, flat at the bottom (still emerging
      from the key). On release, .barReleased rounds the bottom too. */
   border-radius: 999px 999px 0 0;
-  background: var(--primary);
+  background: var(--w-primary);
   box-shadow:
     0 0 6px rgba(0, 212, 177, 0.25),
     inset 0 -1px 0 rgba(0, 0, 0, 0.18);
@@ -494,7 +494,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background: var(--primary);
+  background: var(--w-primary);
   border-radius: 999px;
 }
 
@@ -506,7 +506,7 @@
   border-radius: 50%;
   background: #fff;
   box-shadow:
-    0 0 0 2px var(--primary),
+    0 0 0 2px var(--w-primary),
     0 1px 4px rgba(0, 0, 0, 0.5);
   transform: translate(-50%, 50%);
   pointer-events: none;
@@ -567,7 +567,7 @@
 }
 
 .whiteKeyPressed {
-  background: linear-gradient(180deg, var(--primary) 0%, #33ffe0 100%);
+  background: linear-gradient(180deg, var(--w-primary) 0%, #33ffe0 100%);
   border-bottom-color: rgba(0, 0, 0, 0.4);
   box-shadow:
     inset 0 6px 12px rgba(0, 0, 0, 0.15),
@@ -733,7 +733,7 @@
 
 .scrubberFill {
   height: 100%;
-  background: var(--primary);
+  background: var(--w-primary);
   border-radius: 290486px;
 }
 
@@ -745,7 +745,7 @@
   border-radius: 50%;
   background: #fff;
   box-shadow:
-    0 0 0 2px var(--primary),
+    0 0 0 2px var(--w-primary),
     0 1px 4px rgba(0, 0, 0, 0.5);
   transform: translate(-50%, -50%);
   pointer-events: none;

--- a/components/wustep/MidiVisualizer.module.css
+++ b/components/wustep/MidiVisualizer.module.css
@@ -329,7 +329,7 @@
   bottom: 0;
   /* While pressed: rounded at the top, flat at the bottom (still emerging
      from the key). On release, .barReleased rounds the bottom too. */
-  border-radius: 999px 999px 0 0;
+  border-radius: var(--radius-pill) var(--radius-pill) 0 0;
   background: var(--w-primary);
   box-shadow:
     0 0 6px rgba(0, 212, 177, 0.25),
@@ -347,7 +347,7 @@
 }
 
 .barReleased {
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition: border-radius 220ms ease;
 }
 
@@ -479,7 +479,7 @@
   width: 6px;
   height: 110px;
   background: rgba(255, 255, 255, 0.1);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   touch-action: none;
 }
@@ -495,7 +495,7 @@
   left: 0;
   width: 100%;
   background: var(--w-primary);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .volumeThumb {
@@ -719,7 +719,7 @@
   width: 100%;
   height: 6px;
   background: rgba(255, 255, 255, 0.1);
-  border-radius: 290486px;
+  border-radius: var(--radius-pill);
   overflow: hidden;
   transition: height 120ms ease;
 }
@@ -734,7 +734,7 @@
 .scrubberFill {
   height: 100%;
   background: var(--w-primary);
-  border-radius: 290486px;
+  border-radius: var(--radius-pill);
 }
 
 .scrubberThumb {

--- a/components/wustep/MidiVisualizer.tsx
+++ b/components/wustep/MidiVisualizer.tsx
@@ -1032,11 +1032,11 @@ function DropOverlay() {
           {/* Music note inside */}
           <path
             d='M 56 44 L 56 64 Q 56 70 50 70 Q 44 70 44 65 Q 44 60 50 60 Q 52 60 54 60.6 L 54 50 L 64 47.5 L 64 44 Z'
-            fill='var(--primary)'
+            fill='var(--w-primary)'
             opacity='0.9'
           />
           {/* Plus badge */}
-          <circle cx='72' cy='70' r='12' fill='var(--primary)' />
+          <circle cx='72' cy='70' r='12' fill='var(--w-primary)' />
           <path
             d='M 72 64 L 72 76 M 66 70 L 78 70'
             stroke='#04201a'

--- a/components/wustep/PlaygroundLayout.tsx
+++ b/components/wustep/PlaygroundLayout.tsx
@@ -191,16 +191,16 @@ function LayoutContent({
         <div className='relative ml-auto flex items-center gap-2'>
           <Link
             href='/'
-            className='playground-home-button playground-action-button inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors'
+            className='playground-home-button playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors after:absolute after:-inset-1.5'
             aria-label='Go home'
           >
             <HouseFillIcon className='playground-home-icon h-4 w-4' />
           </Link>
-          <OwnerModeToggle className='playground-owner-mode-toggle playground-action-button h-8 w-8 rounded-md text-base' />
+          <OwnerModeToggle className='playground-owner-mode-toggle playground-action-button relative h-8 w-8 rounded-md text-base after:absolute after:-inset-1.5' />
           <ThemeToggle
             isDark={hasMounted ? isDarkMode : false}
             onToggle={toggleDarkMode}
-            className='playground-theme-button playground-action-button inline-flex h-8 w-8 items-center justify-center rounded-md'
+            className='playground-theme-button playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
           />
         </div>
       </header>

--- a/components/wustep/PlaygroundSidebar.tsx
+++ b/components/wustep/PlaygroundSidebar.tsx
@@ -156,12 +156,12 @@ export function PlaygroundSidebar({
                       onBlur={resetDescription}
                     >
                       {item.disabled ? (
-                        <span className='flex w-full items-center justify-between gap-2 text-muted-foreground/60'>
+                        // The menu button's aria-disabled:opacity-50 is the
+                        // single dimmer; don't stack a second opacity here.
+                        <span className='flex w-full items-center justify-between gap-2 text-muted-foreground'>
                           <span className='truncate'>{item.title}</span>
                           {item.year ? (
-                            <span className='text-[11px] text-muted-foreground/60'>
-                              {item.year}
-                            </span>
+                            <span className='text-[11px]'>{item.year}</span>
                           ) : null}
                         </span>
                       ) : (
@@ -171,7 +171,7 @@ export function PlaygroundSidebar({
                         >
                           <span className='truncate'>{item.title}</span>
                           {item.year ? (
-                            <span className='text-[11px] text-muted-foreground/60'>
+                            <span className='text-[11px] text-muted-foreground'>
                               {item.year}
                             </span>
                           ) : null}
@@ -192,7 +192,7 @@ export function PlaygroundSidebar({
         </div>
         <p>{aboutInfo.description}</p>
         {metadataItems.length ? (
-          <p className='mt-1 text-[11px] text-muted-foreground/80 flex items-center gap-1'>
+          <p className='mt-1 text-[11px] text-muted-foreground flex items-center gap-1'>
             {metadataItems.map((item, index) => (
               <React.Fragment key={index}>
                 {index > 0 ? <span aria-hidden='true'>&bull;</span> : null}

--- a/components/wustep/ShadcnPhysicsCover.module.css
+++ b/components/wustep/ShadcnPhysicsCover.module.css
@@ -106,7 +106,7 @@
   }
   82% {
     transform: translate(-3.5cqw, 37cqh) rotate(-162deg) scaleY(0.96);
-    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    animation-timing-function: var(--ease-out-smooth);
   }
   92% {
     transform: translate(-3.5cqw, 38cqh) rotate(-156deg) scaleY(1);
@@ -132,7 +132,7 @@
   }
   85% {
     transform: translate(2.5cqw, 31cqh) rotate(82deg) scaleY(0.97);
-    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    animation-timing-function: var(--ease-out-smooth);
   }
   94% {
     transform: translate(2.5cqw, 32cqh) rotate(77deg) scaleY(1);

--- a/components/wustep/lenses/DesignPanel.module.css
+++ b/components/wustep/lenses/DesignPanel.module.css
@@ -64,7 +64,7 @@
   transition:
     background 160ms ease,
     border-color 160ms ease,
-    transform 120ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 120ms var(--ease-out-smooth);
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.3),
     0 12px 28px -12px rgba(0, 0, 0, 0.45);
@@ -168,10 +168,10 @@
 
 .panel {
   transition:
-    right 320ms cubic-bezier(0.22, 1, 0.36, 1),
-    left 320ms cubic-bezier(0.22, 1, 0.36, 1),
-    bottom 320ms cubic-bezier(0.22, 1, 0.36, 1),
-    top 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    right 320ms var(--ease-out-smooth),
+    left 320ms var(--ease-out-smooth),
+    bottom 320ms var(--ease-out-smooth),
+    top 320ms var(--ease-out-smooth),
     align-items 0s linear 320ms;
 }
 
@@ -256,7 +256,7 @@
     background 140ms ease,
     border-color 140ms ease,
     color 140ms ease,
-    transform 100ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 100ms var(--ease-out-smooth);
 }
 
 .iconBtn svg {
@@ -532,7 +532,7 @@
   background: var(--panel-fg);
   border: none;
   cursor: grab;
-  transition: transform 120ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 120ms var(--ease-out-smooth);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 

--- a/components/wustep/lenses/DesignPanel.module.css
+++ b/components/wustep/lenses/DesignPanel.module.css
@@ -25,7 +25,7 @@
   position: fixed;
   bottom: 18px;
   right: 18px;
-  z-index: 9999;
+  z-index: var(--z-toast); /* top band: floats above the lenses modal ladder */
   font-family:
     var(--font-geist, var(--font-sans, system-ui)),
     system-ui,
@@ -150,7 +150,7 @@
 /* ───── Dodge the lens side-panel ─────
  *
  * When a lens detail panel is open, the dev DesignPanel is
- * functionally clickable (z-index 9999 vs 60) but visually
+ * functionally clickable (--z-toast vs the modal band) but visually
  * obscured because both anchor to the same edge by default.
  * Slide the DesignPanel to the opposite side of whichever edge
  * the lens panel is anchored to, so both surfaces stay usable.

--- a/components/wustep/lenses/DesignPanel.module.css
+++ b/components/wustep/lenses/DesignPanel.module.css
@@ -55,7 +55,7 @@
   backdrop-filter: blur(14px) saturate(160%);
   -webkit-backdrop-filter: blur(14px) saturate(160%);
   border: 1px solid var(--panel-stroke);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--panel-fg);
   font: inherit;
   font-weight: 500;
@@ -89,7 +89,7 @@
 .handleDot {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--panel-accent);
   box-shadow: 0 0 12px var(--panel-accent);
 }
@@ -393,7 +393,7 @@
 
 .sections::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.16);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 2px solid transparent;
   background-clip: padding-box;
 }
@@ -513,7 +513,7 @@
   -webkit-appearance: none;
   height: 4px;
   background: rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   outline: none;
   cursor: pointer;
   margin: 0;
@@ -528,7 +528,7 @@
   -webkit-appearance: none;
   width: 14px;
   height: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--panel-fg);
   border: none;
   cursor: grab;
@@ -548,7 +548,7 @@
 .slider::-moz-range-thumb {
   width: 14px;
   height: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--panel-fg);
   border: none;
   cursor: grab;

--- a/components/wustep/lenses/LensesIllustrationLab.module.css
+++ b/components/wustep/lenses/LensesIllustrationLab.module.css
@@ -125,7 +125,7 @@
   gap: 8px;
   min-height: 38px;
   border: 1px solid var(--lab-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 4px 5px 4px 12px;
   font-size: 0.74rem;
   font-weight: 750;
@@ -140,7 +140,7 @@
 .themeToggle {
   width: 30px;
   height: 30px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--lab-text);
   background: var(--lab-stat-bg);
   font-size: 1rem;
@@ -450,7 +450,7 @@
   padding: 3px;
   gap: 2px;
   border: 1px solid var(--lab-control-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--lab-control-bg);
 }
 
@@ -461,7 +461,7 @@
   min-height: 30px;
   padding: 0 14px;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font: inherit;
   font-size: 0.78rem;
   font-weight: 700;
@@ -609,7 +609,7 @@
 .warnMessage {
   display: inline-flex;
   margin-top: 18px !important;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 8px 11px;
   font-size: 0.84rem;
   font-weight: 700;
@@ -845,7 +845,7 @@
   top: 9px;
   right: 9px;
   padding: 3px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-size: 0.62rem;
   font-weight: 800;
   letter-spacing: 0.06em;

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -70,7 +70,8 @@
 
 .frame {
   position: relative;
-  min-height: 100vh;
+  min-height: 100vh; /* fallback for browsers without dvh */
+  min-height: 100dvh;
   /* Establish an inline-size container so the canvas responds to
      the *frame's* width, not the viewport. This matters in
      embedded mode (e.g. /playground/lenses) where the playground
@@ -2049,7 +2050,8 @@
   top: 50%;
   transform: translate(-50%, -50%);
   width: min(var(--design-dialog-width, 760px), calc(100vw - 32px));
-  max-height: calc(100vh - 64px);
+  max-height: calc(100vh - 64px); /* fallback */
+  max-height: calc(100dvh - 64px);
   background: #faf7ee;
   border-radius: var(--design-dialog-radius, 18px);
   box-shadow:

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -247,7 +247,7 @@
   justify-content: center;
   width: 34px;
   height: 34px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid rgba(0, 0, 0, 0.12);
   background: rgba(255, 255, 255, 0.5);
   color: inherit;
@@ -1542,7 +1542,7 @@
   border: none;
   cursor: pointer;
   color: var(--panel-fg);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition:
     background 200ms ease,
     transform 150ms var(--ease-spring-snap);
@@ -1943,7 +1943,7 @@
   padding: 9px 12px 9px 9px;
   background: rgba(0, 0, 0, 0.04);
   border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-family: var(--font-geist, var(--font-sans), system-ui, sans-serif);
   font-size: 0.84rem;
   font-weight: 500;
@@ -2367,7 +2367,7 @@
   border: none;
   cursor: pointer;
   color: inherit;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition:
     background 200ms ease,
     transform 150ms var(--ease-spring-snap);

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -593,6 +593,10 @@
   cursor: pointer;
   font-family: var(--font-geist, var(--font-sans, system-ui), sans-serif);
   opacity: 0;
+  /* Not just transparent: unclickable and out of the a11y tree until
+     the entrance reveals it (visibility flips instantly — it's not in
+     the transition list). */
+  visibility: hidden;
   transform: scale(0.96);
   /* Default = hover-OUT timing. Hover-in overrides below with a
      much shorter duration so the card lifts under the cursor
@@ -628,6 +632,7 @@
 
 .cardVisible {
   opacity: 1;
+  visibility: visible;
   transform: scale(1);
   /* Entrance uses a one-shot animation rather than a transition
      so the base `.card` rule keeps owning `transform` for later
@@ -1131,6 +1136,8 @@
   cursor: pointer;
   font-family: var(--font-geist, var(--font-sans), system-ui, sans-serif);
   opacity: 0;
+  /* Unclickable and out of the a11y tree until revealed (see .card). */
+  visibility: hidden;
   transform: scale(0.94);
   transition:
     opacity 700ms var(--ease-out-quint),
@@ -1178,6 +1185,7 @@
 
 .centerCardVisible {
   opacity: 1;
+  visibility: visible;
   transform: scale(1);
   /* The entrance gets a longer exponential ease; afterwards the
      base rule owns the shorter interaction timing. */

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -20,21 +20,10 @@
  *     • prefers-reduced-motion disables all animation, no exceptions
  * ========================================================================== */
 
-/* Reusable easing — kept narrow so we can tune timing globally.
-   The hover hot-path uses --ease-out-snap exclusively: a sharp
-   curve that lands *cleanly* without the trailing tail that
-   makes quart/quint ease-outs feel sluggish at short durations.
-   Quart/quint stay around for entrance animations (300ms+) where
-   their gentler arc reads as graceful rather than draggy. */
+/* Easing tokens (--ease-out-*) are owned by styles/globals.css :root —
+   the hover hot-path uses --ease-out-snap (lands cleanly at short
+   durations); quart/quint suit 300ms+ entrances. */
 .frame {
-  --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
-  --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
-  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
-  /* Sharp ease-out that lands *cleanly*. Second control point
-     at (0.2, 1) means ~80% travel by 50% time, then the last
-     20% completes quickly instead of trailing. The curve to use
-     for short hover/press transforms. */
-  --ease-out-snap: cubic-bezier(0.2, 0.9, 0.2, 1);
   /* Legacy aliases keep the existing interaction rules readable
      while removing overshoot from the motion system. */
   --ease-spring-soft: var(--ease-out-expo);

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -181,7 +181,7 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 10;
+  z-index: var(--z-sticky);
   /* Account for iOS notch / Android cutouts. */
   padding: max(18px, env(safe-area-inset-top)) 22px 0;
 }
@@ -1289,7 +1289,8 @@
   background: rgba(20, 20, 22, var(--design-overlay-dim, 0.4));
   backdrop-filter: blur(var(--design-overlay-blur, 3px));
   -webkit-backdrop-filter: blur(var(--design-overlay-blur, 3px));
-  z-index: 50;
+  /* Modal band ladder: overlay < panel < dialog overlay < dialog. */
+  z-index: var(--z-modal);
 }
 
 .panelOverlay[data-state='open'] {
@@ -1315,7 +1316,7 @@
   background: #faf7ee;
   display: flex;
   flex-direction: column;
-  z-index: 60;
+  z-index: calc(var(--z-modal) + 1);
   outline: none;
   font-family: var(--font-sans, system-ui, sans-serif);
   color: #1a1a1a;
@@ -2022,7 +2023,7 @@
   background: rgba(20, 20, 22, calc(var(--design-overlay-dim, 0.4) + 0.15));
   backdrop-filter: blur(calc(var(--design-overlay-blur, 3px) * 2));
   -webkit-backdrop-filter: blur(calc(var(--design-overlay-blur, 3px) * 2));
-  z-index: 70;
+  z-index: calc(var(--z-modal) + 2);
 }
 
 .dialogOverlay[data-state='open'] {
@@ -2046,7 +2047,7 @@
   box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.1),
     0 30px 80px -20px rgba(0, 0, 0, 0.4);
-  z-index: 80;
+  z-index: calc(var(--z-modal) + 3);
   outline: none;
   overflow: hidden;
   font-family: var(--font-sans, system-ui, sans-serif);

--- a/components/wustep/lenses/LensesPage.module.css
+++ b/components/wustep/lenses/LensesPage.module.css
@@ -4536,7 +4536,13 @@
   }
 
   .panelHero {
-    padding: 26px 24px 22px;
+    padding: max(26px, calc(env(safe-area-inset-top) + 12px)) 24px 22px;
+  }
+
+  /* Keep the close/prev/next cluster clear of the status bar / notch. */
+  .panelControls {
+    top: max(20px, calc(env(safe-area-inset-top) + 8px));
+    right: max(20px, env(safe-area-inset-right));
   }
 
   .panelTitle {
@@ -4544,12 +4550,12 @@
   }
 
   .panelBody {
-    padding: 24px 24px 32px;
+    padding: 24px 24px max(32px, calc(env(safe-area-inset-bottom) + 16px));
     font-size: 1.04rem;
   }
 
   .dialogHeader {
-    padding: 22px 22px 14px;
+    padding: max(22px, calc(env(safe-area-inset-top) + 10px)) 22px 14px;
   }
 
   .dialogLede {
@@ -4557,7 +4563,7 @@
   }
 
   .dialogList {
-    padding: 14px 22px 22px;
+    padding: 14px 22px max(22px, calc(env(safe-area-inset-bottom) + 12px));
     grid-template-columns: 1fr;
   }
 }

--- a/components/wustep/lenses/cards.tsx
+++ b/components/wustep/lenses/cards.tsx
@@ -143,6 +143,8 @@ function LensCardImpl({
       type='button'
       className={className}
       style={style}
+      // Invisible cards shouldn't be tab stops during the entrance.
+      tabIndex={visible ? undefined : -1}
       onAnimationEnd={(event) => {
         if (event.currentTarget === event.target) setInteractionReady(true)
       }}
@@ -242,6 +244,8 @@ function CenterCardImpl({ stage, onOpen, previewOverride }: CenterCardProps) {
       type='button'
       className={`${styles.centerCard} ${visible ? styles.centerCardVisible : ''}`}
       style={style}
+      // Invisible during the entrance — keep it out of the tab order.
+      tabIndex={visible ? undefined : -1}
       onClick={() => onOpenRef.current()}
       aria-label={`Open: ${deck.center.title} index`}
       data-lens-id='__center__'

--- a/components/wustep/lenses/llms/LlmsDirectory.module.css
+++ b/components/wustep/lenses/llms/LlmsDirectory.module.css
@@ -7,7 +7,7 @@
  * ========================================================================== */
 
 .frame {
-  --ease-out-snap: cubic-bezier(0.2, 0.9, 0.2, 1);
+  /* --ease-out-snap comes from styles/globals.css :root */
   position: relative;
   min-height: 100vh;
   display: flex;

--- a/components/wustep/prompting/PromptingPage.module.css
+++ b/components/wustep/prompting/PromptingPage.module.css
@@ -104,7 +104,7 @@
   font-size: 1.15em;
   line-height: 1;
   transform: translateX(2px);
-  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 200ms var(--ease-out-smooth);
 }
 
 .homeBackButton:hover .homeBackArrow {
@@ -161,9 +161,9 @@
   align-items: center;
   gap: 0.08em 0.3em;
   transition:
-    opacity 600ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 600ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 600ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 600ms var(--ease-out-swift),
+    transform 600ms var(--ease-out-swift),
+    filter 600ms var(--ease-out-swift);
   will-change: opacity, transform, filter;
 }
 
@@ -259,9 +259,9 @@
   transform: translateY(0.35em);
   filter: blur(8px);
   transition:
-    opacity 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 700ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 700ms var(--ease-out-swift),
+    transform 700ms var(--ease-out-swift),
+    filter 700ms var(--ease-out-swift);
 }
 
 .titleVisible .titleWord {
@@ -293,9 +293,9 @@
   transform: translateY(8px);
   filter: blur(6px);
   transition:
-    opacity 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 700ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 700ms var(--ease-out-swift),
+    transform 700ms var(--ease-out-swift),
+    filter 700ms var(--ease-out-swift);
   will-change: opacity, transform, filter;
 }
 
@@ -326,8 +326,8 @@
   border: none !important;
   background-image: none !important;
   transition:
-    background 200ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    background 200ms var(--ease-out-smooth),
+    transform 200ms var(--ease-out-smooth);
 }
 
 .beginCta:hover {
@@ -337,7 +337,7 @@
 
 .beginCtaArrow {
   display: inline-block;
-  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 220ms var(--ease-out-smooth);
 }
 
 .beginCta:hover .beginCtaArrow {
@@ -483,9 +483,9 @@
   transform: translateY(8px);
   filter: blur(4px);
   transition:
-    opacity 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 700ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 700ms var(--ease-out-swift),
+    transform 700ms var(--ease-out-swift),
+    filter 700ms var(--ease-out-swift);
 }
 
 .chapterBodyVisible {
@@ -609,7 +609,7 @@
   pointer-events: none;
   transition:
     opacity 180ms ease,
-    transform 180ms cubic-bezier(0.32, 0.72, 0, 1);
+    transform 180ms var(--ease-out-swift);
 }
 
 /* Invisible bridge spanning the gap between the trigger and the
@@ -754,7 +754,7 @@
   transition:
     background 180ms ease,
     border-color 180ms ease,
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 220ms var(--ease-out-smooth);
 }
 
 .chapterNavLink:hover {
@@ -793,7 +793,7 @@
   font-weight: 700;
   letter-spacing: -0.005em;
   color: var(--fg-color, rgb(55, 53, 47));
-  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 220ms var(--ease-out-smooth);
 }
 
 :global(.dark-mode) .chapterNavLabel {
@@ -803,7 +803,7 @@
 .chapterNavArrow {
   font-size: 1.2rem;
   color: var(--fg-color-3, rgba(55, 53, 47, 0.55));
-  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 220ms var(--ease-out-smooth);
 }
 
 .chapterNavLink:hover .chapterNavArrow {
@@ -988,9 +988,9 @@
   transform: translateY(10px);
   filter: blur(6px);
   transition:
-    opacity 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 700ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 700ms var(--ease-out-swift),
+    transform 700ms var(--ease-out-swift),
+    filter 700ms var(--ease-out-swift);
   will-change: opacity, transform, filter;
 }
 
@@ -1059,9 +1059,9 @@
   transform: translateY(8px);
   filter: blur(4px);
   transition:
-    opacity 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 700ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 700ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 700ms var(--ease-out-swift),
+    transform 700ms var(--ease-out-swift),
+    filter 700ms var(--ease-out-swift);
   will-change: opacity, transform, filter;
 }
 
@@ -1261,7 +1261,7 @@
     background 160ms ease,
     color 160ms ease,
     border-color 160ms ease,
-    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 200ms var(--ease-out-smooth);
 }
 
 .colleagueChip:hover {
@@ -1306,7 +1306,7 @@
   border-radius: 0;
   background: var(--fg-color-0, rgba(55, 53, 47, 0.04));
   border: 1px solid var(--fg-color-1, rgba(55, 53, 47, 0.08));
-  animation: colleagueFade 320ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: colleagueFade 320ms var(--ease-out-swift);
 }
 
 :global(.dark-mode) .colleagueResponseBody {
@@ -1480,7 +1480,7 @@
 /* Curve fill — fades in once trigger hits */
 .eloChartCurveFill {
   opacity: 0;
-  transition: opacity 700ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: opacity 700ms var(--ease-out-swift);
   transition-delay: 200ms;
 }
 
@@ -1492,7 +1492,7 @@
 .eloChartCurveStroke {
   stroke-dasharray: 100;
   stroke-dashoffset: 100;
-  transition: stroke-dashoffset 1400ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: stroke-dashoffset 1400ms var(--ease-out-swift);
   transition-delay: 300ms;
 }
 
@@ -1576,7 +1576,7 @@
 
 .eloChartMarker {
   opacity: 0;
-  transition: opacity 600ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: opacity 600ms var(--ease-out-swift);
 }
 
 /* You marker — second ink */
@@ -1621,7 +1621,7 @@
 
 .eloChartGap {
   opacity: 0;
-  transition: opacity 600ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: opacity 600ms var(--ease-out-swift);
 }
 
 .eloChartVisible .eloChartGap {
@@ -1750,7 +1750,7 @@
 .recapTitleArrow {
   font-size: 0.85em;
   color: var(--fg-color-3, rgba(55, 53, 47, 0.4));
-  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 200ms var(--ease-out-smooth);
 }
 
 .recapTitle:hover .recapTitleArrow {
@@ -2128,7 +2128,7 @@
   text-decoration: none !important;
   transition:
     border-color 160ms ease,
-    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 200ms var(--ease-out-smooth);
 }
 
 .skillsLink:hover {
@@ -2261,12 +2261,12 @@
   min-height: 110px;
   /* Fast default — drives the collapse on replay. Expansion gets a slower
      transition by overriding when .equationCardExpanded is added. */
-  transition: gap 500ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: gap 500ms var(--ease-out-swift);
 }
 
 .equationCardExpanded .equationStage {
   gap: 14px;
-  transition: gap 1400ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: gap 1400ms var(--ease-out-swift);
 }
 
 .equationLine {
@@ -2279,12 +2279,12 @@
   letter-spacing: 0.02em;
   /* Fast default — used when collapsing back to initial state on replay. */
   transition:
-    opacity 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    font-size 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    max-height 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    gap 500ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 500ms var(--ease-out-swift),
+    transform 500ms var(--ease-out-swift),
+    filter 500ms var(--ease-out-swift),
+    font-size 500ms var(--ease-out-swift),
+    max-height 500ms var(--ease-out-swift),
+    gap 500ms var(--ease-out-swift);
   will-change: opacity, transform, filter, font-size;
 }
 
@@ -2309,11 +2309,11 @@
   /* Slow expansion when going INTO the settled state. Going back to
      un-settled uses the base .equationLine transition (fast). */
   transition:
-    opacity 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    font-size 1400ms cubic-bezier(0.32, 0.72, 0, 1),
-    gap 1400ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 1500ms var(--ease-out-swift),
+    transform 1500ms var(--ease-out-swift),
+    filter 1500ms var(--ease-out-swift),
+    font-size 1400ms var(--ease-out-swift),
+    gap 1400ms var(--ease-out-swift);
 }
 
 .equationSimpleSettled .token {
@@ -2332,9 +2332,9 @@
   transform: translateY(-4px) scale(0.8);
   /* Fast default — collapse direction. */
   transition:
-    opacity 400ms cubic-bezier(0.32, 0.72, 0, 1),
-    max-height 400ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 400ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 400ms var(--ease-out-swift),
+    max-height 400ms var(--ease-out-swift),
+    transform 400ms var(--ease-out-swift);
 }
 
 .equationArrowVisible {
@@ -2343,9 +2343,9 @@
   transform: translateY(0) scale(1);
   /* Slow + delayed when expanding INTO visible. */
   transition:
-    opacity 900ms cubic-bezier(0.32, 0.72, 0, 1),
-    max-height 1100ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 900ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 900ms var(--ease-out-swift),
+    max-height 1100ms var(--ease-out-swift),
+    transform 900ms var(--ease-out-swift);
   transition-delay: 350ms;
 }
 
@@ -2370,10 +2370,10 @@
   /* Slow + delayed when entering visible state. Collapse uses
      .equationLine base transition (fast). */
   transition:
-    opacity 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    filter 1500ms cubic-bezier(0.32, 0.72, 0, 1),
-    max-height 1400ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 1500ms var(--ease-out-swift),
+    transform 1500ms var(--ease-out-swift),
+    filter 1500ms var(--ease-out-swift),
+    max-height 1400ms var(--ease-out-swift);
   transition-delay: 500ms;
 }
 
@@ -2560,8 +2560,8 @@
   opacity: 0;
   transform: translateY(2px);
   transition:
-    opacity 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 500ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 500ms var(--ease-out-swift),
+    transform 500ms var(--ease-out-swift);
   transition-delay: 0ms;
 }
 
@@ -2830,7 +2830,7 @@
   transition:
     background 180ms ease,
     border-color 180ms ease,
-    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 200ms var(--ease-out-smooth);
 }
 
 :global(.dark-mode) .treeCell {
@@ -2869,7 +2869,7 @@
   background: var(--fg-color-1, rgba(55, 53, 47, 0.18));
   transition:
     background 200ms ease,
-    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 200ms var(--ease-out-smooth);
 }
 
 :global(.dark-mode) .treeCellDot {
@@ -2936,7 +2936,7 @@
   font-size: 0.98rem;
   line-height: 1.55;
   color: var(--fg-color, rgb(55, 53, 47));
-  animation: promptFadeIn 320ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: promptFadeIn 320ms var(--ease-out-swift);
 }
 
 :global(.dark-mode) .treeOutputText {
@@ -3111,7 +3111,7 @@
   padding: 6px 0;
   font-size: 0.85rem;
   color: #c01957;
-  animation: errorIn 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: errorIn 220ms var(--ease-out-swift);
 }
 
 :global(.dark-mode) .promptError {
@@ -3292,7 +3292,7 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  animation: menuIn 160ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: menuIn 160ms var(--ease-out-swift);
   transform-origin: bottom left;
 }
 
@@ -3370,7 +3370,7 @@
   color: var(--pm-on-accent, #fcfcfb);
   cursor: pointer;
   transition:
-    transform 120ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 120ms var(--ease-out-smooth),
     opacity 150ms ease;
 }
 
@@ -3395,8 +3395,8 @@
   align-items: center;
   justify-content: center;
   transition:
-    opacity 220ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 220ms var(--ease-out-swift),
+    transform 280ms var(--ease-out-swift);
 }
 
 .submitIconHidden {
@@ -3582,8 +3582,8 @@
   opacity: 0;
   transform: translateY(8px);
   transition:
-    opacity 500ms cubic-bezier(0.32, 0.72, 0, 1),
-    transform 500ms cubic-bezier(0.32, 0.72, 0, 1);
+    opacity 500ms var(--ease-out-swift),
+    transform 500ms var(--ease-out-swift);
 }
 
 .practiceLoopVisible .practiceLadder b {
@@ -3787,7 +3787,7 @@
 }
 
 .orchDiagramVisible .orchTimelineBlock {
-  animation: orchBlockGrow 360ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchBlockGrow 360ms var(--ease-out-swift) forwards;
 }
 
 @keyframes orchBlockGrow {
@@ -3840,7 +3840,7 @@
 }
 
 .orchDiagramVisible .orchFanDrop {
-  animation: orchFadeIn 500ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchFadeIn 500ms var(--ease-out-swift) forwards;
 }
 
 .orchFanTrack {
@@ -3848,7 +3848,7 @@
 }
 
 .orchDiagramVisible .orchFanTrack {
-  animation: orchFadeIn 600ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchFadeIn 600ms var(--ease-out-swift) forwards;
 }
 
 .orchFanMerge {
@@ -3861,7 +3861,7 @@
 }
 
 .orchDiagramVisible .orchFanMerge {
-  animation: orchFadeIn 600ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchFadeIn 600ms var(--ease-out-swift) forwards;
   animation-delay: 900ms;
 }
 
@@ -3914,7 +3914,7 @@
 }
 
 .orchDiagramVisible .orchRoleCard {
-  animation: orchFadeIn 600ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchFadeIn 600ms var(--ease-out-swift) forwards;
 }
 
 .orchRoleName {
@@ -3944,7 +3944,7 @@
 }
 
 .orchDiagramVisible .orchRoleHandoff {
-  animation: orchFadeIn 500ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+  animation: orchFadeIn 500ms var(--ease-out-swift) forwards;
 }
 
 .orchRoleHandoffArtifact {

--- a/components/wustep/prompting/PromptingPage.module.css
+++ b/components/wustep/prompting/PromptingPage.module.css
@@ -3245,7 +3245,7 @@
 .modelDot {
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--pm-accent, #b8401f);
   box-shadow: 0 0 0 0 var(--pm-accent-line, rgba(184, 64, 31, 0.38));
   animation: dotPulse 2.4s ease-in-out infinite;

--- a/components/wustep/prompting/PromptingPresentation.module.css
+++ b/components/wustep/prompting/PromptingPresentation.module.css
@@ -908,7 +908,7 @@
   left: 50%;
   display: block;
   width: 28px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: linear-gradient(180deg, rgba(244, 238, 227, 0.2), var(--ember));
   transform-origin: bottom center;
 }
@@ -945,7 +945,7 @@
   width: 34px;
   height: 34px;
   border: 6px solid #12110f;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--paper);
   box-shadow: 0 0 0 2px rgba(244, 238, 227, 0.25);
   transform: translateX(-50%);
@@ -1092,7 +1092,7 @@
   left: 0;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--ember);
 }
 
@@ -1164,7 +1164,7 @@
   aspect-ratio: 1;
   overflow: hidden;
   border: 3px solid rgba(232, 162, 65, 0.72);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: #eadfce;
   box-shadow:
     0 0 0 10px rgba(232, 162, 65, 0.1),
@@ -1493,7 +1493,7 @@
   position: absolute;
   width: 86px;
   height: 12px;
-  border-radius: 99px;
+  border-radius: var(--radius-pill);
   background: rgba(244, 238, 227, 0.14);
 }
 
@@ -3224,7 +3224,7 @@
   left: 60%;
   width: 14px;
   height: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--paper);
   box-shadow: 0 0 0 3px rgba(223, 107, 45, 0.42);
   transform: translate(-50%, -50%);

--- a/components/wustep/prompting/PromptingPresentation.module.css
+++ b/components/wustep/prompting/PromptingPresentation.module.css
@@ -8,7 +8,8 @@
   --magenta: #b83280;
   --violet: #6d48bf;
   --teal: #0f766e;
-  min-height: 100vh;
+  min-height: 100vh; /* fallback for browsers without dvh */
+  min-height: 100dvh;
   padding: 18px;
   background:
     radial-gradient(
@@ -26,7 +27,8 @@
 .presenterFullscreen {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  height: 100vh;
+  height: 100vh; /* fallback for browsers without dvh */
+  height: 100dvh;
   padding: 14px;
 }
 
@@ -133,7 +135,8 @@
   grid-template-columns: minmax(0, 0.92fr) minmax(360px, 0.78fr);
   gap: clamp(28px, 5vw, 72px);
   width: min(1280px, calc(100vw - 36px));
-  min-height: min(720px, calc(100vh - 108px));
+  min-height: min(720px, calc(100vh - 108px)); /* fallback */
+  min-height: min(720px, calc(100dvh - 108px));
   margin: 0 auto;
   padding: clamp(42px, 6vw, 76px);
   overflow: hidden;
@@ -314,7 +317,8 @@
 }
 
 .notesPage {
-  min-height: 100vh;
+  min-height: 100vh; /* fallback for browsers without dvh */
+  min-height: 100dvh;
   padding: clamp(24px, 5vw, 64px);
   background: #12110f;
   color: var(--paper, #f4eee3);

--- a/components/wustep/prompting/PromptingPresentation.module.css
+++ b/components/wustep/prompting/PromptingPresentation.module.css
@@ -142,7 +142,7 @@
   overflow: hidden;
   border: 1px solid rgba(244, 238, 227, 0.12);
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.35);
-  animation: slideIn 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: slideIn 280ms var(--ease-out-smooth);
 }
 
 .slide::before {
@@ -526,7 +526,7 @@
   margin-left: auto;
   opacity: 0;
   transform: translateY(28px) scale(0.96);
-  animation: promptCardEnter 740ms cubic-bezier(0.22, 1, 0.36, 1) 520ms forwards;
+  animation: promptCardEnter 740ms var(--ease-out-smooth) 520ms forwards;
 }
 
 .articlePromptDemo > * {
@@ -777,7 +777,7 @@
 .eloCurveStroke {
   stroke-dasharray: 100;
   stroke-dashoffset: 100;
-  animation: eloCurveDraw 700ms cubic-bezier(0.22, 1, 0.36, 1) 100ms forwards;
+  animation: eloCurveDraw 700ms var(--ease-out-smooth) 100ms forwards;
 }
 
 .eloCurveAxis {
@@ -911,7 +911,7 @@
   bottom: 0;
   height: 122px;
   transform: translateX(-50%);
-  animation: forkBaseGrow 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: forkBaseGrow 620ms var(--ease-out-smooth) both;
 }
 
 .forkRoadLeft,
@@ -923,13 +923,13 @@
 .forkRoadLeft {
   transform: translateX(-50%) rotate(-38deg);
   opacity: 0.42;
-  animation: forkBranchGrow 680ms cubic-bezier(0.22, 1, 0.36, 1) 380ms both;
+  animation: forkBranchGrow 680ms var(--ease-out-smooth) 380ms both;
 }
 
 .forkRoadRight {
   transform: translateX(-50%) rotate(38deg);
   background: linear-gradient(180deg, rgba(232, 162, 65, 0.24), var(--gold));
-  animation: forkBranchGrow 680ms cubic-bezier(0.22, 1, 0.36, 1) 520ms both;
+  animation: forkBranchGrow 680ms var(--ease-out-smooth) 520ms both;
 }
 
 .forkRoadDot {
@@ -943,7 +943,7 @@
   background: var(--paper);
   box-shadow: 0 0 0 2px rgba(244, 238, 227, 0.25);
   transform: translateX(-50%);
-  animation: forkDotPop 360ms cubic-bezier(0.22, 1, 0.36, 1) 820ms both;
+  animation: forkDotPop 360ms var(--ease-out-smooth) 820ms both;
 }
 
 .fork section,
@@ -990,7 +990,7 @@
 .fork section {
   opacity: 0;
   transform: translateY(18px);
-  animation: forkBoxEnter 540ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: forkBoxEnter 540ms var(--ease-out-smooth) forwards;
 }
 
 .forkClosed {
@@ -1519,7 +1519,7 @@
   background: rgba(244, 238, 227, 0.05);
   opacity: 0;
   transform: translateY(10px);
-  animation: choiceEnter 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: choiceEnter 480ms var(--ease-out-smooth) forwards;
 }
 
 .choiceHeader {
@@ -1595,7 +1595,7 @@
   box-shadow: 0 14px 36px rgba(18, 17, 15, 0.14);
   opacity: 0;
   transform: translateY(10px);
-  animation: colleagueEnter 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: colleagueEnter 480ms var(--ease-out-smooth) forwards;
 }
 
 .colleagueCard header {
@@ -1828,7 +1828,7 @@
   display: block;
   height: 28px;
   transform-origin: left;
-  animation: barReveal 780ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: barReveal 780ms var(--ease-out-smooth) both;
 }
 
 .you,
@@ -1912,7 +1912,7 @@
   display: block;
   height: 24px;
   transform-origin: left;
-  animation: barReveal 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: barReveal 700ms var(--ease-out-smooth) both;
 }
 
 .staggerYou {
@@ -2425,7 +2425,7 @@
   color: var(--ink);
   opacity: 0;
   transform: translateY(8px);
-  animation: contextRowEnter 460ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: contextRowEnter 460ms var(--ease-out-smooth) forwards;
 }
 
 .contextStackV2Row:nth-child(2) {
@@ -2693,7 +2693,7 @@
   background: rgba(244, 238, 227, 0.06);
   opacity: 0;
   transform: translateY(8px);
-  animation: roleEnter 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: roleEnter 480ms var(--ease-out-smooth) forwards;
 }
 
 .roleName {
@@ -2715,7 +2715,7 @@
   gap: 4px;
   min-width: 96px;
   opacity: 0;
-  animation: roleEnter 480ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: roleEnter 480ms var(--ease-out-smooth) forwards;
 }
 
 .roleHandoffArtifact {
@@ -2987,7 +2987,7 @@
   border: 1px solid rgba(244, 238, 227, 0.2);
   background: #1a1714;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
-  animation: goToEnter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation: goToEnter 220ms var(--ease-out-smooth);
 }
 
 .goTo label {

--- a/components/wustep/prompting/PromptingPresentation.module.css
+++ b/components/wustep/prompting/PromptingPresentation.module.css
@@ -8,6 +8,10 @@
   --magenta: #b83280;
   --violet: #6d48bf;
   --teal: #0f766e;
+  /* One elevation for floating dark surfaces (slide, demos, dialogs) —
+     replaces four hand-tuned near-duplicates. Local (not a global token)
+     because this surface is fixed-dark regardless of site theme. */
+  --shadow-overlay: 0 24px 72px rgba(0, 0, 0, 0.32);
   min-height: 100vh; /* fallback for browsers without dvh */
   min-height: 100dvh;
   padding: 18px;
@@ -141,7 +145,7 @@
   padding: clamp(42px, 6vw, 76px);
   overflow: hidden;
   border: 1px solid rgba(244, 238, 227, 0.12);
-  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-overlay);
   animation: slideIn 280ms var(--ease-out-smooth);
 }
 
@@ -317,6 +321,8 @@
 }
 
 .notesPage {
+  /* Same fixed-dark elevation as .presenter (separate root, same world). */
+  --shadow-overlay: 0 24px 72px rgba(0, 0, 0, 0.32);
   min-height: 100vh; /* fallback for browsers without dvh */
   min-height: 100dvh;
   padding: clamp(24px, 5vw, 64px);
@@ -530,7 +536,7 @@
 }
 
 .articlePromptDemo > * {
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+  box-shadow: var(--shadow-overlay);
 }
 
 .articleEquationDemo,
@@ -2573,7 +2579,7 @@
 .briefPair section.briefGood {
   border-color: rgba(232, 162, 65, 0.55);
   background: #221a13;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  box-shadow: var(--shadow-overlay);
 }
 
 .briefPair section.briefGood span {
@@ -2986,7 +2992,7 @@
   padding: 22px 26px;
   border: 1px solid rgba(244, 238, 227, 0.2);
   background: #1a1714;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-overlay);
   animation: goToEnter 220ms var(--ease-out-smooth);
 }
 

--- a/components/wustep/prompting/PromptingPresentation.module.css
+++ b/components/wustep/prompting/PromptingPresentation.module.css
@@ -2957,7 +2957,7 @@
   place-items: center;
   background: rgba(18, 17, 15, 0.62);
   backdrop-filter: blur(6px);
-  z-index: 100;
+  z-index: var(--z-modal);
   animation: scrimFade 180ms ease-out;
 }
 

--- a/components/wustep/prompting/PromptingPresentation.tsx
+++ b/components/wustep/prompting/PromptingPresentation.tsx
@@ -651,9 +651,14 @@ function GoToOverlay({
 }) {
   const [value, setValue] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const scrimRef = React.useRef<HTMLDivElement | null>(null)
 
   React.useEffect(() => {
+    const previouslyFocused = document.activeElement
     inputRef.current?.focus()
+    return () => {
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus()
+    }
   }, [])
 
   const submit = (event: React.FormEvent) => {
@@ -666,13 +671,46 @@ function GoToOverlay({
     }
   }
 
+  // Modal behavior the window-level handler can't provide: Escape works
+  // even while the input is focused, and Tab cycles inside the dialog.
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      onClose()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusables =
+      scrimRef.current?.querySelectorAll<HTMLElement>('button, input')
+    if (!focusables?.length) return
+    const first = focusables[0]
+    const last = focusables.at(-1)
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last?.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first?.focus()
+    }
+  }
+
   return (
-    <div className={styles.goToScrim} role='dialog' aria-label='Go to slide'>
+    <div
+      ref={scrimRef}
+      className={styles.goToScrim}
+      role='dialog'
+      aria-modal='true'
+      aria-label='Go to slide'
+    >
+      {/* The key handler sits on each interactive element (focus is
+          trapped among them) — jsx-a11y disallows it on the dialog div. */}
       <button
         type='button'
         className={styles.goToScrimButton}
         aria-label='Close'
         onClick={onClose}
+        onKeyDown={handleKeyDown}
       />
       <form className={styles.goTo} onSubmit={submit}>
         <label htmlFor='go-to-input'>Go to slide</label>
@@ -686,8 +724,11 @@ function GoToOverlay({
           value={value}
           onChange={(event) => setValue(event.target.value)}
           placeholder={`1–${count}`}
+          onKeyDown={handleKeyDown}
         />
-        <button type='submit'>jump</button>
+        <button type='submit' onKeyDown={handleKeyDown}>
+          jump
+        </button>
       </form>
     </div>
   )

--- a/components/wustep/prompting/PromptingPresentation.tsx
+++ b/components/wustep/prompting/PromptingPresentation.tsx
@@ -681,9 +681,11 @@ function GoToOverlay({
       return
     }
     if (event.key !== 'Tab') return
-    const focusables =
-      scrimRef.current?.querySelectorAll<HTMLElement>('button, input')
-    if (!focusables?.length) return
+    const focusables = [
+      ...(scrimRef.current?.querySelectorAll<HTMLElement>('button, input') ??
+        [])
+    ]
+    if (focusables.length === 0) return
     const first = focusables[0]
     const last = focusables.at(-1)
     if (event.shiftKey && document.activeElement === first) {

--- a/docs/improvements-2026-07-11.md
+++ b/docs/improvements-2026-07-11.md
@@ -6,140 +6,140 @@
 ## UI/UX & Design
 
 ### 1. Resolve the two-token-system `:root` collision (wustep.css silently overrides shadcn)
-- **Impact:** 🔴 high · **Effort:** L · **Status:** ⬜ proposed
+- **Impact:** 🔴 high · **Effort:** L · **Status:** ✅ accepted
 - **Problem.** `styles/globals.css` and `styles/wustep.css` both define the same variable names at `:root` — `--primary`, `--secondary`, `--accent`, `--background`, and `--radius-sm/md/lg` (globals.css:125–142 as `oklch(...)` + :57–59 as `calc(var(--radius) …)`, vs wustep.css:9–12,37–39 as hex/px). `pages/_app.tsx:18` imports wustep.css last, so its values win the cascade for every shadcn/Tailwind component: `rounded-sm` resolves to wustep's 4px instead of shadcn's ~6px, and `bg-primary`/`text-primary` pull wustep's hex, not the oklch scale. `pages/design/theme.tsx:143–184` re-maps tokens only inside the theme preview, not globally. The `--dw-*` workbench vocabulary is duplicated (13 identical keys) in both files.
 - **Proposal.** Pick one owner per token: namespace wustep's tokens (e.g. `--w-primary`) or move the shadcn palette to non-colliding names, have `@theme inline` map to the intended source, delete the duplicated `--dw-*` block from one file, and add a "who owns which token" table to `docs/styling.md`.
 - **Risks / trade-offs.** Touches globally-consumed tokens; a rename can regress Notion-track pages or shadcn components. Needs a visual pass in light and dark across /design, /playground, About, and Notion pages.
 - **Files.** `styles/globals.css`, `styles/wustep.css`, `pages/_app.tsx`, `pages/design/theme.tsx`, `docs/styling.md`
 
 ### 2. `_error` page renders "Error undefined" — wire up statusCode
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `pages/_error.tsx` only re-exports `ErrorPage`; there is no `getInitialProps`, so `statusCode` is `undefined` on real 500s and client-side crashes. `components/ErrorPage.tsx` renders it as the giant number (line 19), sets `<title>Error undefined</title>` (line 7), and always shows the non-500 copy (lines 8–11). This is the site's top-level crash screen.
 - **Proposal.** Add `getInitialProps = ({ res, err }) => ({ statusCode: res?.statusCode ?? err?.statusCode ?? 500 })` and guard the display so a missing code falls back to a friendly label.
 - **Risks / trade-offs.** `getInitialProps` on `_error` opts it out of static optimization (already true for `_error`); verify both SSR 500s and client-transition errors.
 - **Files.** `pages/_error.tsx`, `components/ErrorPage.tsx`
 
 ### 3. Stop hiding the entire About page until JS runs
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `components/AboutPage.module.css` `.page` starts at `opacity: 0` (line 7) and only becomes visible via `.visible` (line 37), applied by `useAnimateIn()` in `AboutPage.tsx` (lines 88–95) inside a post-mount `requestAnimationFrame`. The fully server-rendered About page is invisible until hydration — blank on slow devices, permanently blank if the JS bundle fails.
 - **Proposal.** Default `.page` to visible and make the entrance fade opt-in (class added synchronously before paint on the JS-enabled path), or animate a child wrapper so SSR content always paints.
 - **Risks / trade-offs.** The entrance fade won't play on the very first paint for no-JS users (acceptable); ensure no flash for JS users.
 - **Files.** `components/AboutPage.tsx`, `components/AboutPage.module.css`
 
 ### 4. Fix the split dark-mode mechanism and the dead shadcn `.dark` variant
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `styles/globals.css:10` declares `@custom-variant dark (&:is(.dark *))`, but nothing ever applies a `.dark` class — `pages/_document.tsx:19–23` and `lib/use-dark-mode.ts:4` toggle only `dark-mode`. The shadcn `dark:` variant is a latent trap. globals.css binds the shadcn dark palette to `.dark-mode` (165–197) while wustep.css also overrides the same names there (63–71), so `bg-background` resolves to wustep's `#0d0d0d`, not the oklch value.
 - **Proposal.** Rewrite the variant to `@custom-variant dark (&:is(.dark-mode *))` (or also toggle `.dark` in the noflash script and hook), then dedupe the dark-token overrides so one file owns them.
 - **Risks / trade-offs.** Aligning the selector could activate previously-inert styling if `dark:` utilities are added later; verify no third-party CSS keys off `.dark`.
 - **Files.** `styles/globals.css`, `styles/wustep.css`, `pages/_document.tsx`, `lib/use-dark-mode.ts`
 
 ### 5. Fix iOS Safari viewport jumps on full-screen surfaces (100vh → dvh/svh)
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** Full-height surfaces still use `100vh`, which on iOS Safari includes the collapsing toolbar area: `PromptingPresentation.module.css` `.presenterFullscreen { height: 100vh }` (:29) and `.presenter { min-height: 100vh }` (:11); `LensesPage.module.css` `.frame { min-height: 100vh }` (:73) and dialog `max-height: calc(100vh - 64px)` (:1990); `AboutPage.module.css` `.page { min-height: 100vh }` (:3). The codebase already uses `100dvh` elsewhere (LensesPage.module.css:429, 4451–4452, design pages), so treatment is inconsistent.
 - **Proposal.** Switch these to `100dvh` with a `100vh` fallback line first (or `svh` where a stable viewport is better, e.g. the presenter slide).
 - **Risks / trade-offs.** `dvh` recalculates as the URL bar animates (subtle resize during scroll); `svh` leaves a gap when the bar collapses — pick per surface.
 - **Files.** `components/wustep/prompting/PromptingPresentation.module.css`, `components/wustep/lenses/LensesPage.module.css`, `components/AboutPage.module.css`
 
 ### 6. Kill the default tap-highlight box on the touch-first card surfaces
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** No global `-webkit-tap-highlight-color` reset exists — the only occurrence is scoped to `styles/applause.css:19`. On iOS, tapping lens cards, CenterDialog items, playground project links, and header buttons flashes the default gray rectangle, undermining the deck's carefully designed `:active` scale/shadow feedback (`LensesPage.module.css:741–769`).
 - **Proposal.** Add `-webkit-tap-highlight-color: transparent` to interactive elements (`a, button, [role="button"]`) in `styles/globals.css`, relying on existing designed `:active` states; spot-check every tappable control has visible press feedback.
 - **Risks / trade-offs.** Controls lacking their own `:active` state lose feedback — audit plain Notion links; scope to custom surfaces if a blanket reset is too broad.
 - **Files.** `styles/globals.css`, `styles/wustep.css`, `components/wustep/lenses/LensesPage.module.css`, `pages/playground/index.tsx`
 
 ### 7. Respect safe-area insets on the full-bleed lenses panel and index dialog
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** On phones the SidePanel is edge-to-edge (`.panel { width: 100vw }`, LensesPage.module.css:4423) and the CenterDialog fills the screen (`.dialog { height: 100dvh }`, :4451), but padding is plain pixels: `.panelHero` (4474–4476), `.panelBody` (4482–4485), `.dialogList`/`.dialogHeader` (4487–4498). The close/prev/next cluster at `top: 20px` (:1472) can tuck under the notch; list rows sit under the home indicator. `.cards` already does it right with `max(28px, env(safe-area-inset-bottom))` (:4384).
 - **Proposal.** Add `env(safe-area-inset-*)` to the phone rules — top inset for `.panelHero`/`.panelControls`/`.dialogHeader`, bottom inset for `.panelBody`/`.dialogList`, mirroring the `.cards` approach.
 - **Risks / trade-offs.** Insets are 0 on non-notched devices; verify hero art isn't pushed too far down, and consider landscape (left/right) insets for panel controls.
 - **Files.** `components/wustep/lenses/LensesPage.module.css`
 
 ### 8. Bring primary icon controls up to the 44px touch-target bar
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** PRODUCT.md commits to touch-friendly targets, but: the Playground `SidebarTrigger` is 28px (`components/ui/sidebar.tsx:277`), the Playground header home/owner/theme buttons are 32px (`PlaygroundLayout.tsx:192–204`), Lenses `.headerButton` is 34px (`LensesPage.module.css:~258`), About `.navIcon` is 40px (`AboutPage.module.css`). The Footer already does it right at 44px (`components/styles.module.css:106–107`).
 - **Proposal.** Expand hit areas to ≥44px — keep glyph sizes, add padding or an invisible `::before` expander, prioritizing `SidebarTrigger` (sole open/close affordance on mobile) and the Playground header row.
 - **Risks / trade-offs.** Larger targets can crowd the compact 55px Playground header; use expanders rather than growing visible chrome.
 - **Files.** `components/ui/sidebar.tsx`, `components/wustep/PlaygroundLayout.tsx`, `components/wustep/lenses/LensesPage.module.css`, `components/AboutPage.module.css`
 
 ### 9. Raise sub-threshold low-contrast text in the Playground sidebar
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `PlaygroundSidebar.tsx` renders meaningful copy at heavily reduced opacity: disabled items and years at `text-muted-foreground/60` (:159, :162–165, :174–177), the About body at `text-muted-foreground` (:188), the metadata row at `text-muted-foreground/80` in 11px (:195). `muted-foreground` at 60–80% opacity is very likely below WCAG 2.2 AA 4.5:1 for small text — and it's the sidebar's primary descriptive copy.
 - **Proposal.** Measure these pairings in light and `.dark`; raise disabled/metadata text to full `muted-foreground` (or a dedicated AA-passing token) and reserve opacity dimming for decorative elements.
 - **Risks / trade-offs.** More legible disabled items weaken the "disabled" affordance — pair contrast with a non-color cue.
 - **Files.** `components/wustep/PlaygroundSidebar.tsx`, `styles/globals.css`
 
 ### 10. Stop hiding scrollbars site-wide; unify the inner-scrollbar treatment
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `styles/wustep.css:1289–1297` hides scrollbars globally (`::-webkit-scrollbar { display: none }` + `body { scrollbar-width: none }`), removing the scroll-position cue on the main page for everyone. The inner panels that do style scrollbars are inconsistent: `DesignWorkbench.module.css:226` and `pages/design/fonts.module.css:118` use `scrollbar-color: #b4b5b0 transparent`; `DesignPanel.module.css:382–394` uses `rgba(255,255,255,0.16)` with a separate webkit block — three looks, none tokenized, one with no dark-mode variant.
 - **Proposal.** Remove (or narrowly scope) the global hide; define one tokenized thin-scrollbar recipe (`scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) transparent`) reused by inner panels with a dark-mode value.
 - **Risks / trade-offs.** Scrollbars appear on pages designed assuming none — check Notion content pages and horizontal-overflow layouts for unexpected gutters.
 - **Files.** `styles/wustep.css`, `components/design/DesignWorkbench.module.css`, `pages/design/fonts.module.css`, `components/wustep/lenses/DesignPanel.module.css`
 
 ### 11. Close reduced-motion gaps and stop animating layout properties on hover
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `components/Page404.module.css` runs 800–1000ms entrance choreography (`fadeIn`, `expandLine` at :19,:43,:51,:71,:80,:99,:127) plus a hover transform (:111) with no `prefers-reduced-motion` guard — unlike nearly every other module. `components/PageSocial.module.css:53–58` animates `width`/`height` 0→100% on hover (layout-thrashing; should be `transform`), also unguarded, and hardcodes `color: #ffffff` (:84).
 - **Proposal.** Add `@media (prefers-reduced-motion: reduce)` blocks mirroring the existing site pattern; reimplement PageSocial's expanding circle with `transform: scale()` from a fixed-size element; tokenize the hardcoded white.
 - **Risks / trade-offs.** `scale()` changes the fill-reveal feel slightly; verify the hover still reads as a fill, not a zoom.
 - **Files.** `components/Page404.module.css`, `components/PageSocial.module.css`
 
 ### 12. Make the About-page inline tooltips reachable by keyboard and screen readers
-- **Impact:** 🟡 med · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** The `Tooltip` in `components/AboutPage.tsx` (:97–137) reveals only on `:hover` (`AboutPage.module.css:1211–1216`) and `:focus-within` (:1142), but two of three bio tooltips wrap non-focusable `<span className={styles.bioHint}>` triggers (:232–237, :239–244) — `focus-within` never fires. The tooltip node has no `role="tooltip"`/`id` and triggers have no `aria-describedby`, so screen readers get nothing.
 - **Proposal.** Make text triggers focusable (`tabindex=0` + `aria-describedby`), give the tooltip `role="tooltip"` and an `id`, reveal on `:hover, :focus-visible` — or swap to Radix Tooltip (already in deps).
 - **Risks / trade-offs.** Adds tabstops to inline hero text; keep to the three intentional hints.
 - **Files.** `components/AboutPage.tsx`, `components/AboutPage.module.css`
 
 ### 13. Replace the generic loading spinner with a designed, theme-aware Notion skeleton
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** `pages/[pageId].tsx` uses `fallback: true` (:79, :94), so uncached pages render `<Loading/>` during ISR; `NotionPage.tsx:348–354` does the same for redirects. The spinner color is hardcoded `rgba(55, 53, 47, 0.4)` (`components/styles.module.css:37`), `LoadingIcon.tsx` hardcodes gray gradient stops, and styles.module.css:20 carries the TODO "swap to dark mode aware colors". In dark mode it's a low-contrast gray blob — against PRODUCT.md's dark-parity commitment.
 - **Proposal.** Build a lightweight skeleton mirroring a Notion article shell (cover band, title, byline, paragraph bars) with `components/ui/skeleton.tsx` + shadcn tokens for the `router.isFallback` branch; at minimum derive the spinner color from `currentColor`/tokens.
 - **Risks / trade-offs.** Skeleton geometry won't match every page type; keep it generic to avoid a jarring swap; preserve the absolute-fill layout.
 - **Files.** `components/Loading.tsx`, `components/LoadingIcon.tsx`, `components/styles.module.css`, `components/NotionPage.tsx`, `components/ui/skeleton.tsx`
 
 ### 14. Pause off-screen playground cover animations to protect mobile perf/battery
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** `pages/playground/index.tsx:44–46` renders every `CoverComponent` eagerly. `LensesCover`, `MidiVisualizerCover`, `StageBenchCover`, and `ShadcnPhysicsCover` module CSS all run `@keyframes` (several `infinite`), and no cover is gated by visibility — `lib/use-in-view.ts` exists but no `*Cover.tsx` uses it. Many simultaneous off-screen loops hurt scroll smoothness and battery on phones.
 - **Proposal.** Gate looping covers with `lib/use-in-view.ts` (`animation-play-state: paused` off-screen; don't mount rAF loops), plus `content-visibility: auto` on the cover container.
 - **Risks / trade-offs.** Pausing/resuming can visibly restart animations — prefer `animation-play-state` over unmounting; reduced-motion is already covered by wustep.css:107.
 - **Files.** `pages/playground/index.tsx`, `components/wustep/*Cover.tsx`, `components/wustep/*Cover.module.css`, `lib/use-in-view.ts`
 
 ### 15. Consolidate motion tokens and eliminate raw-bezier / duration sprawl
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** Easing tokens exist (`globals.css:160–162`) but are duplicated and diverging: `--ease-out-quart/quint` redefined in `LensesPage.module.css:30–31`, `--ease-out-snap` defined in both LensesPage.module.css:37 and `LlmsDirectory.module.css:10`. Most motion bypasses tokens: `cubic-bezier(0.32, 0.72, 0, 1)` appears 62×, `cubic-bezier(0.22, 1, 0.36, 1)` 47×, and durations span 60→1400ms with no `--duration-*` scale.
 - **Proposal.** Promote shared easings + a small duration scale (`--dur-fast/base/slow`) to globals `:root`, delete duplicate token blocks, replace the two highest-frequency raw beziers with `var(--ease-…)`; leave bespoke deck curves scoped but named.
 - **Risks / trade-offs.** Deck animations were hand-tuned; substitute curve-by-curve only where values match a token exactly.
 - **Files.** `styles/globals.css`, `components/wustep/lenses/LensesPage.module.css`, `components/wustep/lenses/llms/LlmsDirectory.module.css`, `components/wustep/prompting/PromptingPresentation.module.css`
 
 ### 16. Actually use the z-index scale that already exists (and kill `z-index: 9999`)
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** `globals.css:23–29` defines a semantic scale (`--z-base:1 … --z-toast:300`) with a "never hardcode large values" comment, yet only 6 sites consume it. `DesignPanel.module.css:28` uses `z-index: 9999`; LensesPage and PromptingPresentation scatter 0–200 across stacking contexts with no shared meaning (two unrelated `z-index: 100` and two `z-index: 200` in LensesPage at :4727/:4780).
 - **Proposal.** Replace 9999 and large ad-hoc values with the semantic tokens; wrap locally-ordered groups in `isolation: isolate` with small integers; document the scale in `docs/styling.md`.
 - **Risks / trade-offs.** Re-mapping can expose latent overlap bugs (modal vs sticky header vs deck cards); test /lenses dialogs and /prompting interactions.
 - **Files.** `components/wustep/lenses/DesignPanel.module.css`, `components/wustep/lenses/LensesPage.module.css`, `components/wustep/prompting/PromptingPresentation.module.css`, `components/wustep/MidiVisualizer.module.css`
 
 ### 17. Introduce an elevation/shadow token scale
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** ~40 unique bespoke `box-shadow` declarations with no elevation system — near-duplicates like `0 20px 60px rgba(0,0,0,0.28)`, `0 24px 70px rgba(0,0,0,0.28)`, `0 24px 80px rgba(0,0,0,0.4)`, `0 28px 80px rgba(0,0,0,0.35)` each appear once; focus rings vary across multiple 2px/3px accent tints. All alphas are hardcoded `rgba(0,0,0,x)` — no dark-aware elevation, no single depth knob.
 - **Proposal.** Define `--shadow-sm/md/lg/xl` + `--shadow-focus` in globals, tuned for light and `.dark-mode`, and replace recurring card/dialog/focus shadows. Keep artistic cover glows local.
 - **Risks / trade-offs.** Shadows carry surface character; scope to structural surfaces (cards, dialogs, panels, focus), not cover art.
 - **Files.** `styles/globals.css`, `components/wustep/lenses/LensesPage.module.css`, `components/wustep/prompting/PromptingPresentation.module.css`, `components/wustep/*Cover.module.css`
 
 ### 18. Standardize the radius scale and the pill convention
-- **Impact:** 🟡 med · **Effort:** M · **Status:** ⬜ proposed
+- **Impact:** 🟡 med · **Effort:** M · **Status:** ✅ accepted
 - **Problem.** "Fully rounded" is expressed three ways: `999px` (26×), `290486px` (`MidiVisualizer.module.css:722,:737` — the Bulma magic number), and `99px` (`PromptingPresentation.module.css:1486`). Small radii are hardcoded 2–18px across modules while `--radius-sm/md/lg` go almost unused (only `Page404.module.css:122`). The idea-1 collision also means `components/ui/*` render at wustep's px values.
 - **Proposal.** Standardize a `--radius-pill: 9999px` token and replace the variants; map common small radii to `--radius-sm/md/lg` where a component isn't intentionally bespoke.
 - **Risks / trade-offs.** Don't force-tokenize intentional cover-art radii; the pill swap itself is visually a no-op.
 - **Files.** `components/wustep/MidiVisualizer.module.css`, `components/wustep/prompting/PromptingPresentation.module.css`, `styles/globals.css`, `docs/styling.md`
 
 ### 19. Give the prompting "Go to slide" overlay real dialog behavior
-- **Impact:** ⚪ low · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** ⚪ low · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `GoToOverlay` in `PromptingPresentation.tsx:646–694` renders `role="dialog"` (:670) with no `aria-modal="true"` and no focus trap — Tab escapes to the slide controls behind the scrim, and focus isn't restored to the trigger on close. Escape only works via a window-level handler (:436–441).
 - **Proposal.** Add `aria-modal="true"`, trap Tab within the form (or reuse Radix Dialog as the Lenses surfaces do), and restore focus on close.
 - **Risks / trade-offs.** Niche surface; a minimal manual focus-guard is smaller than a Radix swap.
 - **Files.** `components/wustep/prompting/PromptingPresentation.tsx`
 
 ### 20. Stop lens cards being focusable and clickable while invisible during the entrance
-- **Impact:** ⚪ low · **Effort:** S · **Status:** ⬜ proposed
+- **Impact:** ⚪ low · **Effort:** S · **Status:** ✅ accepted
 - **Problem.** `LensCard`/`CenterCard` (`cards.tsx:142`) always render an interactive `<button>`; the base `.card` is `opacity: 0` (`LensesPage.module.css:543`) until `.cardVisible` (:577), with no `visibility: hidden`/`inert`/`tabIndex=-1`. During the first-visit entrance (`LensesPage.tsx:217–227`), all ~32 cards are tabbable and clickable while fully transparent — keyboard focus lands on invisible controls, violating the visible-focus commitment.
 - **Proposal.** Gate interactivity on visibility: `tabIndex={visible ? undefined : -1}` (or `inert`) until the card's stage is reached, and/or `visibility: hidden` in the base state.
 - **Risks / trade-offs.** Reduced-motion/repeat visits snap straight to `STAGE.cards` — guard the gating to the animated path only.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -21,14 +21,19 @@ Configured by [`postcss.config.js`](../postcss.config.js) using `@tailwindcss/po
 - Dark mode: `@custom-variant dark (&:is(.dark *))` — toggled by a `dark` class on the root element.
 - The shadcn token system (`--background`, `--foreground`, etc.) sits in `:root` in `globals.css`.
 
-## The two overlapping token systems
+## The two token systems (namespaced)
 
-There's a design-system overlap worth knowing about:
+The two tracks used to define the *same* variable names (`--primary`, `--background`, …) at `:root`, and wustep.css — imported last — silently won the cascade for every shadcn utility. The wustep track is now namespaced so the systems can't collide. Who owns which token:
 
-- `styles/wustep.css` `:root` — `--primary`, `--secondary`, `--accent`, `--background`, etc. Used by the Notion page and custom components (AboutPage, WustepFooter, etc.).
-- `styles/globals.css` `:root` — shadcn/Tailwind tokens for the UI kit in [`components/ui/`](../components/ui/).
+| Namespace | Owner | Examples | Consumers |
+|---|---|---|---|
+| `--w-*` | `styles/wustep.css` | `--w-primary`, `--w-secondary`, `--w-accent`, `--w-background`, `--w-surface`, `--w-divider` | Notion pages, Page404/ErrorPage, MidiVisualizer, `/design` pages' custom CSS |
+| shadcn names | `styles/globals.css` | `--background`, `--foreground`, `--primary`, `--muted-foreground`, `--sidebar*` | Tailwind utilities + [`components/ui/`](../components/ui/) |
+| `--dw-*` | `styles/globals.css` | `--dw-accent`, `--dw-field-h`, `--dw-radius-*` | `/design` workbench shell + tools |
+| `--about-*` | `components/AboutPage.module.css` | `--about-text`, `--about-accent` | About page (theme workbench overrides them in preview) |
+| shared | `styles/wustep.css` (`--space-*`, `--radius-sm/md/lg`, `--font-*`) and `styles/globals.css` (`--z-*`, `--ease-*`) | | both tracks |
 
-They don't conflict because they cover mostly disjoint component sets, but new components should pick a track and stick with it.
+New components should still pick a track and stick with it; never redefine another namespace's token.
 
 ## Dark mode
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -35,11 +35,26 @@ The two tracks used to define the *same* variable names (`--primary`, `--backgro
 
 New components should still pick a track and stick with it; never redefine another namespace's token.
 
+## Z-index scale
+
+`styles/globals.css` defines the semantic scale — use these tokens (or a small `calc(var(--z-modal) + n)` ladder within a band) instead of hardcoding large values:
+
+| Token | Value | Use |
+|---|---|---|
+| `--z-base` | 1 | content that must sit above siblings |
+| `--z-sticky` | 10 | sticky/fixed page chrome (headers) |
+| `--z-dropdown` | 50 | menus, popovers |
+| `--z-tooltip` | 100 | tooltips |
+| `--z-modal` | 200 | scrims, panels, dialogs (the lenses panel/dialog ladder is `--z-modal`+0..3) |
+| `--z-toast` | 300 | top band: toasts, the floating DesignPanel |
+
+Purely local ordering inside a contained component can keep small integers (0–25); wrap the group in `isolation: isolate` if it starts fighting siblings.
+
 ## Dark mode
 
-Driven by [`lib/use-dark-mode.ts`](../lib/use-dark-mode.ts) (a thin wrapper around `@fisch0920/use-dark-mode`). Toggles a `dark-mode` class on `<body>`. `styles/wustep.css` has `.dark-mode { --primary: ...; ... }` blocks that swap the token values.
+Driven by [`lib/use-dark-mode.ts`](../lib/use-dark-mode.ts) (a thin wrapper around `@fisch0920/use-dark-mode`). Toggles a `dark-mode` class on `<body>`. `styles/wustep.css` has `.dark-mode { --w-primary: ...; ... }` blocks that swap the token values.
 
-The shadcn side uses the `dark` class variant — separate mechanism.
+The shadcn side flips on the same class: `globals.css` overrides its tokens under `.dark-mode`, and the Tailwind `dark:` variant is keyed to `.dark-mode` too.
 
 ## CSS modules
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -18,7 +18,7 @@ All five are imported from `pages/_app.tsx` or via `_document.tsx`.
 
 Configured by [`postcss.config.js`](../postcss.config.js) using `@tailwindcss/postcss`. No `tailwind.config.js` — v4 uses CSS-native `@custom-variant` / `@theme` directives inside `globals.css`.
 
-- Dark mode: `@custom-variant dark (&:is(.dark *))` — toggled by a `dark` class on the root element.
+- Dark mode: `@custom-variant dark (&:is(.dark-mode *))` — keyed off the same `dark-mode` body class the Notion track uses, so `dark:` utilities and the `.dark-mode` token overrides flip together.
 - The shadcn token system (`--background`, `--foreground`, etc.) sits in `:root` in `globals.css`.
 
 ## The two token systems (namespaced)

--- a/lib/use-in-view.ts
+++ b/lib/use-in-view.ts
@@ -2,13 +2,15 @@ import * as React from 'react'
 
 /**
  * useInView — observe an element and report when it intersects the
- * viewport. Once seen, the observer disconnects (one-shot).
+ * viewport. By default the observer disconnects once seen (one-shot);
+ * pass `once: false` to keep tracking as the element enters and leaves.
  *
  *   Useful for kicking off entrance animations only when the element
- *   actually scrolls into view.
+ *   actually scrolls into view, or (continuous mode) pausing looping
+ *   animations while it's off-screen.
  */
 export function useInView<T extends HTMLElement>(
-  opts?: IntersectionObserverInit
+  opts?: IntersectionObserverInit & { once?: boolean }
 ) {
   const ref = React.useRef<T>(null)
   const [inView, setInView] = React.useState(false)
@@ -18,14 +20,17 @@ export function useInView<T extends HTMLElement>(
   React.useEffect(() => {
     const node = ref.current
     if (!node) return
+    const { once = true, ...observerOpts } = optsRef.current ?? {}
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry?.isIntersecting) {
           setInView(true)
-          observer.disconnect()
+          if (once) observer.disconnect()
+        } else if (!once) {
+          setInView(false)
         }
       },
-      { threshold: 0.3, ...optsRef.current }
+      { threshold: 0.3, ...observerOpts }
     )
     observer.observe(node)
     return () => observer.disconnect()

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,6 +19,7 @@ import 'styles/wustep.css'
 
 import type { AppProps } from 'next/app'
 import { Analytics, type BeforeSendEvent } from '@vercel/analytics/react'
+import Head from 'next/head'
 
 import {
   OwnerModeProvider,
@@ -44,6 +45,15 @@ function SiteAnalytics() {
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <OwnerModeProvider>
+      {/* viewport-fit=cover lets env(safe-area-inset-*) resolve on every
+          page (PageHead repeats this for Notion pages, but custom surfaces
+          like /lenses don't render PageHead). */}
+      <Head>
+        <meta
+          name='viewport'
+          content='width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover'
+        />
+      </Head>
       <style jsx global>{`
         :root {
           --font-sans: ${inter.style.fontFamily};

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,1 +1,16 @@
-export { ErrorPage as default } from '@/components/ErrorPage'
+import type { NextPageContext } from 'next'
+
+import { ErrorPage } from '@/components/ErrorPage'
+
+function CustomErrorPage({ statusCode }: { statusCode?: number }) {
+  return <ErrorPage statusCode={statusCode} />
+}
+
+// Without this, `statusCode` is undefined on real 500s and client-side
+// crashes, and the page renders a literal "Error undefined".
+CustomErrorPage.getInitialProps = ({ res, err }: NextPageContext) => {
+  const statusCode = res?.statusCode ?? err?.statusCode ?? 500
+  return { statusCode }
+}
+
+export default CustomErrorPage

--- a/pages/design/blocks.module.css
+++ b/pages/design/blocks.module.css
@@ -255,7 +255,7 @@
   width: 100%;
   min-height: 100%;
   margin: 0 auto;
-  background: var(--background);
+  background: var(--w-background);
   transition: width 200ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 

--- a/pages/design/blocks.module.css
+++ b/pages/design/blocks.module.css
@@ -256,7 +256,7 @@
   min-height: 100%;
   margin: 0 auto;
   background: var(--w-background);
-  transition: width 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: width 200ms var(--ease-out-smooth);
 }
 
 .previewLoading {

--- a/pages/design/favicons.module.css
+++ b/pages/design/favicons.module.css
@@ -399,7 +399,7 @@
   background: var(--page-surface);
   transition:
     border-color 160ms ease,
-    transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+    transform 160ms var(--ease-out-smooth);
 }
 
 .card:hover {

--- a/pages/design/fonts.module.css
+++ b/pages/design/fonts.module.css
@@ -39,8 +39,8 @@
   border-right: 1px solid #171815;
   background: var(--panel);
   transition:
-    width 260ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+    width 260ms var(--ease-out-smooth),
+    transform 260ms var(--ease-out-smooth);
 }
 
 .sidebarHeader {

--- a/pages/design/fonts.module.css
+++ b/pages/design/fonts.module.css
@@ -115,7 +115,7 @@
   flex: 1;
   overflow-x: hidden;
   overflow-y: auto;
-  scrollbar-color: #b4b5b0 transparent;
+  scrollbar-color: var(--dw-scrollbar-thumb) transparent;
   scrollbar-width: thin;
 }
 

--- a/pages/design/fonts.module.css
+++ b/pages/design/fonts.module.css
@@ -11,7 +11,7 @@
   --ink: #20211f;
   --muted: #666963;
   --rule: #d7d8d3;
-  --accent: var(--dw-accent);
+  --w-accent: var(--dw-accent);
   --accent-soft: var(--dw-accent-soft);
   --green: #a7f35a;
   display: grid;
@@ -162,7 +162,7 @@
 
 .select:focus,
 .pathInputRow input:focus {
-  border-color: var(--accent);
+  border-color: var(--w-accent);
   background: var(--panel-raised);
   box-shadow: 0 0 0 3px rgba(33, 103, 213, 0.12);
 }
@@ -325,9 +325,9 @@
 }
 
 .activePair .pairCheck {
-  border-color: var(--accent);
+  border-color: var(--w-accent);
   color: white;
-  background: var(--accent);
+  background: var(--w-accent);
 }
 
 .pairCheck svg {
@@ -471,7 +471,7 @@
 
 .activeFont .fontSelected {
   color: white;
-  background: var(--accent);
+  background: var(--w-accent);
 }
 
 .fontSelected svg {
@@ -512,7 +512,7 @@
   width: 100%;
   height: 18px;
   margin: 2px 0 0;
-  accent-color: var(--accent);
+  accent-color: var(--w-accent);
   cursor: ew-resize;
 }
 

--- a/pages/design/index.module.css
+++ b/pages/design/index.module.css
@@ -1,7 +1,7 @@
 .page {
   --bg: #0d0d0d;
-  --surface: rgba(255, 255, 255, 0.045);
-  --surface-hover: rgba(255, 255, 255, 0.075);
+  --w-surface: rgba(255, 255, 255, 0.045);
+  --w-surface-hover: rgba(255, 255, 255, 0.075);
   --text: #e8e8e8;
   --muted: #929292;
   --faint: #686868;
@@ -87,7 +87,7 @@
   padding: 18px;
   border: 1px solid var(--border);
   border-radius: var(--dw-radius-card);
-  background: var(--surface);
+  background: var(--w-surface);
   transition:
     border-color 160ms ease,
     background-color 160ms ease;
@@ -151,7 +151,7 @@
 
   .studyCard:hover {
     border-color: rgba(255, 255, 255, 0.18);
-    background: var(--surface-hover);
+    background: var(--w-surface-hover);
   }
 
   .studyCard:hover .openIcon {

--- a/pages/design/theme.tsx
+++ b/pages/design/theme.tsx
@@ -32,17 +32,17 @@ const tokenDefinitions: Array<{
   label: string
   cssVariable: string
 }> = [
-  { key: 'background', label: 'Background', cssVariable: '--background' },
-  { key: 'primary', label: 'Primary text', cssVariable: '--primary' },
-  { key: 'secondary', label: 'Secondary text', cssVariable: '--secondary' },
-  { key: 'accent', label: 'Accent', cssVariable: '--accent' },
-  { key: 'surface', label: 'Surface', cssVariable: '--surface' },
+  { key: 'background', label: 'Background', cssVariable: '--w-background' },
+  { key: 'primary', label: 'Primary text', cssVariable: '--w-primary' },
+  { key: 'secondary', label: 'Secondary text', cssVariable: '--w-secondary' },
+  { key: 'accent', label: 'Accent', cssVariable: '--w-accent' },
+  { key: 'surface', label: 'Surface', cssVariable: '--w-surface' },
   {
     key: 'surfaceHover',
     label: 'Surface hover',
-    cssVariable: '--surface-hover'
+    cssVariable: '--w-surface-hover'
   },
-  { key: 'divider', label: 'Divider', cssVariable: '--divider' }
+  { key: 'divider', label: 'Divider', cssVariable: '--w-divider' }
 ]
 
 const defaults: ThemeState = {
@@ -155,13 +155,13 @@ function createPreviewStyle(tokens: TokenSet, mode: ThemeMode) {
     `--border: ${tokens.divider} !important;`,
     `--input: ${tokens.divider} !important;`,
     `--ring: ${tokens.accent} !important;`,
-    `--dark-background: ${tokens.background} !important;`,
-    `--dark-primary: ${tokens.primary} !important;`,
-    `--dark-secondary: ${tokens.secondary} !important;`,
-    `--dark-accent: ${tokens.accent} !important;`,
-    `--dark-surface: ${tokens.surface} !important;`,
-    `--dark-surface-hover: ${tokens.surfaceHover} !important;`,
-    `--dark-divider: ${tokens.divider} !important;`
+    `--w-dark-background: ${tokens.background} !important;`,
+    `--w-dark-primary: ${tokens.primary} !important;`,
+    `--w-dark-secondary: ${tokens.secondary} !important;`,
+    `--w-dark-accent: ${tokens.accent} !important;`,
+    `--w-dark-surface: ${tokens.surface} !important;`,
+    `--w-dark-surface-hover: ${tokens.surfaceHover} !important;`,
+    `--w-dark-divider: ${tokens.divider} !important;`
   ].join('\n')
 
   return `:root, html, body, [data-font-root] {

--- a/pages/playground/index.tsx
+++ b/pages/playground/index.tsx
@@ -3,7 +3,27 @@ import * as React from 'react'
 
 import { useOwnerMode } from '@/components/wustep/OwnerModeProvider'
 import { PlaygroundLayout } from '@/components/wustep/PlaygroundLayout'
+import { useInView } from '@/lib/use-in-view'
 import { playgroundEntries } from '@/playground/registry'
+
+/**
+ * Cover cell that pauses its (looping) CSS animations while scrolled
+ * off-screen — several covers run infinite keyframes, and phones shouldn't
+ * pay for paints nobody sees. animation-play-state (see globals.css)
+ * preserves each animation's position instead of restarting it.
+ */
+function CoverCell({ children }: { children: React.ReactNode }) {
+  const [ref, inView] = useInView<HTMLDivElement>({ threshold: 0, once: false })
+  return (
+    <div
+      ref={ref}
+      data-animations-paused={inView ? undefined : ''}
+      className='notion-collection-card-cover aspect-video w-full [content-visibility:auto]'
+    >
+      {children}
+    </div>
+  )
+}
 
 const parseDate = (dateStr?: string): Date => {
   if (!dateStr) return new Date(0)
@@ -40,7 +60,7 @@ export default function PlaygroundPage() {
             href={project.url}
             className='group notion-collection-card relative flex h-full flex-col overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background'
           >
-            <div className='notion-collection-card-cover aspect-video w-full'>
+            <CoverCell>
               {project.CoverComponent ? (
                 <project.CoverComponent />
               ) : project.image ? (
@@ -57,7 +77,7 @@ export default function PlaygroundPage() {
                   }`}
                 />
               )}
-            </div>
+            </CoverCell>
             <div className='notion-collection-card-body p-4 flex-1'>
               <h3 className='font-semibold mb-1'>{project.title}</h3>
               <p className='text-sm text-muted-foreground'>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -40,6 +40,9 @@
   --dw-accent: #2167d5;
   --dw-accent-ink: #164d9c;
   --dw-accent-soft: #e8f1ff;
+  --dw-label-ink: #555751;
+  --dw-meta-ink: #858781;
+  --dw-danger: #9d2f20;
   --dw-ready: #a7f35a;
   --dw-focus: #4a98ec;
   --dw-focus-dark: #69b7f2;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,7 +7,10 @@
 
 @import 'tailwindcss';
 
-@custom-variant dark (&:is(.dark *));
+/* Key the Tailwind dark: variant off the .dark-mode class that
+   lib/use-dark-mode.ts and the _document noflash script actually toggle
+   (nothing ever applies a bare `.dark` class). */
+@custom-variant dark (&:is(.dark-mode *));
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -213,6 +213,18 @@ a {
   text-decoration: none;
 }
 
+/* Rely on each control's designed :active/:hover feedback instead of the
+   translucent gray flash iOS Safari paints over tapped elements. */
+a,
+button,
+[role='button'],
+input,
+select,
+textarea,
+summary {
+  -webkit-tap-highlight-color: transparent;
+}
+
 body,
 html {
   padding: 0;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -46,6 +46,7 @@
   --dw-label-ink: #555751;
   --dw-meta-ink: #858781;
   --dw-danger: #9d2f20;
+  --dw-scrollbar-thumb: #b4b5b0; /* workbench panels are fixed-light */
   --dw-ready: #a7f35a;
   --dw-focus: #4a98ec;
   --dw-focus-dark: #69b7f2;
@@ -166,6 +167,14 @@
   --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
   --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* One thin-scrollbar recipe for small scroll containers:
+     scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) transparent */
+  --scrollbar-thumb: rgba(0, 0, 0, 0.28);
+}
+
+.dark-mode {
+  --scrollbar-thumb: rgba(255, 255, 255, 0.22);
 }
 
 .dark-mode {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -161,12 +161,18 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
-  /* Shared motion vocabulary. The Lenses deck scopes its own copies (plus
-     deck-only curves) on .frame; these canonical tokens let other surfaces
-     (loading, error) move with the same character. */
+  /* Shared motion vocabulary — the single source for easing tokens.
+     (The Lenses deck aliases --ease-spring-* onto these on .frame.) */
   --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
   --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Sharp ease-out that lands cleanly (~80% travel by 50% time) —
+     the curve for short hover/press transforms. */
+  --ease-out-snap: cubic-bezier(0.2, 0.9, 0.2, 1);
+  /* iOS-sheet-style curve the prompting surfaces use as their base ease. */
+  --ease-out-swift: cubic-bezier(0.32, 0.72, 0, 1);
+  /* easings.net easeOutQuint — slightly softer start than --ease-out-quint. */
+  --ease-out-smooth: cubic-bezier(0.22, 1, 0.36, 1);
 
   /* One thin-scrollbar recipe for small scroll containers:
      scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) transparent */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -222,6 +222,12 @@ a {
   text-decoration: none;
 }
 
+/* Freeze (don't restart) every CSS animation inside a container flagged
+   off-screen — see CoverCell in pages/playground/index.tsx. */
+[data-animations-paused] * {
+  animation-play-state: paused !important;
+}
+
 /* Rely on each control's designed :active/:hover feedback instead of the
    translucent gray flash iOS Safari paints over tapped elements. */
 a,

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -150,7 +150,7 @@ h6 {
  */
 .lab-fill-liquid {
   y: 10;
-  transition: y 400ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: y 400ms var(--ease-out-smooth);
 }
 
 @media (hover: hover) {
@@ -202,7 +202,7 @@ h6 {
 @media (hover: hover) {
   .playground-home-button:hover .playground-home-icon {
     color: #09c772;
-    animation: playground-home-hop 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation: playground-home-hop 420ms var(--ease-out-smooth) both;
   }
 
   .playground-home-button:hover .playground-home-icon .house-body {

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -37,6 +37,7 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius-pill: 9999px; /* fully-rounded pills/circles */
   --font-serif: 'Crimson Pro', 'Georgia', serif;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
 
@@ -834,7 +835,7 @@ span[class*='_background'] {
   display: inline-flex;
   align-items: center;
   padding: 0.2rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--w-divider);
   background: var(--w-surface);
   gap: 0.15rem;
@@ -851,7 +852,7 @@ span[class*='_background'] {
   justify-content: center;
   gap: 0.35rem;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 0.3rem 0.85rem;
   background: transparent;
   font-weight: 600;

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -1270,16 +1270,6 @@ span[class*='_background'] {
   border-top: 0.5px solid var(--color-border);
 }
 
-/* Hide scrollbars */
-::-webkit-scrollbar {
-  display: none;
-}
-
-body {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
-
 /**
  * ========== Select pills ==========
  */

--- a/styles/wustep.css
+++ b/styles/wustep.css
@@ -6,24 +6,24 @@
 
 :root {
   /* Color system - matching About page */
-  --primary: #1a1a1a;
-  --secondary: #666;
-  --accent: #000;
-  --background: #ffffff;
-  --surface: rgba(0, 0, 0, 0.03);
-  --surface-hover: rgba(0, 0, 0, 0.06);
-  --divider: rgba(0, 0, 0, 0.08);
-  --divider-hover: rgba(0, 0, 0, 0.15);
+  --w-primary: #1a1a1a;
+  --w-secondary: #666;
+  --w-accent: #000;
+  --w-background: #ffffff;
+  --w-surface: rgba(0, 0, 0, 0.03);
+  --w-surface-hover: rgba(0, 0, 0, 0.06);
+  --w-divider: rgba(0, 0, 0, 0.08);
+  --w-divider-hover: rgba(0, 0, 0, 0.15);
 
   /* Dark mode colors - will be applied via .dark-mode class */
-  --dark-primary: #e8e8e8;
-  --dark-secondary: #888;
-  --dark-accent: #fff;
-  --dark-background: #0d0d0d;
-  --dark-surface: rgba(255, 255, 255, 0.04);
-  --dark-surface-hover: rgba(255, 255, 255, 0.08);
-  --dark-divider: rgba(255, 255, 255, 0.1);
-  --dark-divider-hover: rgba(255, 255, 255, 0.2);
+  --w-dark-primary: #e8e8e8;
+  --w-dark-secondary: #888;
+  --w-dark-accent: #fff;
+  --w-dark-background: #0d0d0d;
+  --w-dark-surface: rgba(255, 255, 255, 0.04);
+  --w-dark-surface-hover: rgba(255, 255, 255, 0.08);
+  --w-dark-divider: rgba(255, 255, 255, 0.1);
+  --w-dark-divider-hover: rgba(255, 255, 255, 0.2);
 
   /* Spacing system */
   --space-xs: 0.25rem;
@@ -40,35 +40,19 @@
   --font-serif: 'Crimson Pro', 'Georgia', serif;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
 
-  /* Design playground (dw) primitives — shared by every /design tool */
-  --dw-field-h: 36px; /* canonical control height */
-  --dw-field-border: #c8cac4; /* input / select / search outline */
-  --dw-label-ink: #555751; /* section / field label text */
-  --dw-meta-ink: #858781; /* counts + de-emphasized secondary text */
-  --dw-danger: #9d2f20; /* inline error text */
-  --dw-accent: #2167d5; /* primary + selected fill */
-  --dw-accent-ink: #164d9c; /* selected text on a soft accent bg */
-  --dw-accent-soft: #e8f1ff;
-  --dw-focus: #4a98ec; /* focus ring on light surfaces */
-  --dw-focus-dark: #69b7f2; /* focus ring on dark surfaces */
-  --dw-segment-track: #e3e4e0; /* segmented-control track */
-  --dw-label-weight: 650; /* section / field label weight */
-  --dw-radius-control: 8px; /* inputs, search fields */
-  --dw-radius-control-sm: 7px; /* chips, icon buttons, segment items */
-  --dw-radius-segment: 9px; /* segmented-control track */
-  --dw-radius-card: 12px;
+  /* Design-workbench (--dw-*) tokens are owned by styles/globals.css */
 }
 
 /* Dark mode */
 .dark-mode {
-  --primary: var(--dark-primary);
-  --secondary: var(--dark-secondary);
-  --accent: var(--dark-accent);
-  --background: var(--dark-background);
-  --surface: var(--dark-surface);
-  --surface-hover: var(--dark-surface-hover);
-  --divider: var(--dark-divider);
-  --divider-hover: var(--dark-divider-hover);
+  --w-primary: var(--w-dark-primary);
+  --w-secondary: var(--w-dark-secondary);
+  --w-accent: var(--w-dark-accent);
+  --w-background: var(--w-dark-background);
+  --w-surface: var(--w-dark-surface);
+  --w-surface-hover: var(--w-dark-surface-hover);
+  --w-divider: var(--w-dark-divider);
+  --w-divider-hover: var(--w-dark-divider-hover);
 }
 
 body {
@@ -87,11 +71,11 @@ h6 {
 }
 
 .notion-app {
-  background: var(--background);
+  background: var(--w-background);
 }
 
 .dark-mode .notion-app {
-  background: var(--dark-background);
+  background: var(--w-dark-background);
 }
 
 /**
@@ -660,7 +644,7 @@ span[class*='_background'] {
     content: '·';
     margin-left: 0.5em;
     margin-right: 0.5em;
-    color: var(--secondary);
+    color: var(--w-secondary);
   }
 }
 
@@ -851,14 +835,14 @@ span[class*='_background'] {
   align-items: center;
   padding: 0.2rem;
   border-radius: 999px;
-  border: 1px solid var(--divider);
-  background: var(--surface);
+  border: 1px solid var(--w-divider);
+  background: var(--w-surface);
   gap: 0.15rem;
 }
 
 .dark-mode .posts-view-toggle {
-  background: var(--dark-surface);
-  border-color: var(--divider);
+  background: var(--w-dark-surface);
+  border-color: var(--w-divider);
 }
 
 .posts-view-toggle__button {
@@ -871,7 +855,7 @@ span[class*='_background'] {
   padding: 0.3rem 0.85rem;
   background: transparent;
   font-weight: 600;
-  color: var(--secondary);
+  color: var(--w-secondary);
   transition:
     background 0.2s ease,
     color 0.2s ease;
@@ -884,18 +868,18 @@ span[class*='_background'] {
 
 @media (hover: hover) {
   .posts-view-toggle__button:hover {
-    color: var(--primary);
+    color: var(--w-primary);
     background: rgba(0, 0, 0, 0.04);
   }
 }
 
 .posts-view-toggle__button--active {
-  background: var(--primary);
-  color: var(--background);
+  background: var(--w-primary);
+  color: var(--w-background);
 }
 
 .posts-view-toggle__button:focus-visible {
-  outline: 2px solid var(--primary);
+  outline: 2px solid var(--w-primary);
   outline-offset: 2px;
 }
 
@@ -1026,17 +1010,17 @@ span[class*='_background'] {
   margin-bottom: 0.1em;
   font-size: 0.82rem;
   line-height: 1.4;
-  color: var(--secondary);
+  color: var(--w-secondary);
 }
 
 .notion-collection-card {
   border-radius: 16px;
-  background: var(--surface);
+  background: var(--w-surface);
   transition:
     transform 0.2s ease,
     background-color 0.3s ease,
     border-color 0.3s ease;
-  border: 1px solid var(--divider);
+  border: 1px solid var(--w-divider);
   box-shadow: none;
   transform-origin: center bottom;
 }
@@ -1044,8 +1028,8 @@ span[class*='_background'] {
 @media (hover: hover) {
   .notion-collection-card:hover {
     transform: translateY(-2px);
-    background: var(--surface-hover);
-    border-color: var(--divider-hover);
+    background: var(--w-surface-hover);
+    border-color: var(--w-divider-hover);
   }
 }
 
@@ -1053,16 +1037,16 @@ span[class*='_background'] {
    lift on focus — tapping or tabbing to a card gives the same affordance. */
 .group.notion-collection-card:focus-within {
   transform: translateY(-2px);
-  background: var(--surface-hover);
-  border-color: var(--divider-hover);
+  background: var(--w-surface-hover);
+  border-color: var(--w-divider-hover);
 }
 
 .notion-collection-card-cover {
   border-radius: 16px 16px 0 0;
   overflow: hidden;
-  border-bottom: 1px solid var(--divider);
+  border-bottom: 1px solid var(--w-divider);
   aspect-ratio: 16/9;
-  background: var(--background);
+  background: var(--w-background);
   transition: border-color 0.3s ease;
 }
 
@@ -1072,7 +1056,7 @@ span[class*='_background'] {
 
 @media (hover: hover) {
   .notion-collection-card:hover .notion-collection-card-cover {
-    border-color: var(--divider-hover);
+    border-color: var(--w-divider-hover);
   }
 
   .notion-collection-card:hover .notion-collection-card-cover img {
@@ -1082,7 +1066,7 @@ span[class*='_background'] {
 
 /* Focus mirror for playground cards (see above) — applies on touch/keyboard. */
 .group.notion-collection-card:focus-within .notion-collection-card-cover {
-  border-color: var(--divider-hover);
+  border-color: var(--w-divider-hover);
 }
 
 .group.notion-collection-card:focus-within .notion-collection-card-cover img {
@@ -1151,12 +1135,12 @@ span[class*='_background'] {
 /* Post header row (author · date) */
 .notion-collection-row {
   font-size: 0.9rem;
-  color: var(--secondary);
+  color: var(--w-secondary);
 }
 
 .notion-asset-caption {
   font-size: 0.82rem;
-  color: var(--secondary);
+  color: var(--w-secondary);
 }
 
 /* Listing pages (/writing, /articles, …): section headings use the About
@@ -1167,7 +1151,7 @@ span[class*='_background'] {
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--secondary);
+  color: var(--w-secondary);
   margin: 3rem 0 0.75rem;
 }
 


### PR DESCRIPTION
Implements all 20 accepted UI/UX ideas from `docs/improvements-2026-07-11.md` (lens: emil-design-engineering), one commit per idea, verified against a live dev server with before/after screenshots at each step.

## Foundations
1. **Token collision fix** — wustep's color tokens are now namespaced `--w-*`; shadcn's `--primary`/`--accent`/`--background`/`--secondary` resolve to the intended oklch scale instead of being silently overridden (e.g. `bg-accent` no longer renders black). `--dw-*` has a single owner. `docs/styling.md` gains an ownership table.
2. **`_error` statusCode wired** — no more "Error undefined" on 500s/client crashes.
3. **About page paints without JS** — entrance fade is now a pure CSS animation instead of an opacity-0 state flipped after hydration.
4. **`dark:` variant fixed** — keyed to the `.dark-mode` class the site actually toggles (was bound to a `.dark` class nothing applies).

## Mobile & touch
5. **`100vh` → `100dvh`** (with fallbacks) on presenter, notes, lenses frame, design dialog, About.
6. **iOS tap-highlight removed** on interactive elements (designed `:active` states take over).
7. **Safe-area insets** on the full-bleed lenses panel/dialog; `viewport-fit=cover` now ships on every page via `_app` (previously only Notion pages had it, so `env()` was 0 on `/lenses`).
8. **44px touch targets** — sidebar trigger (was 28px), playground header buttons (32px), About nav icons (40px) get invisible hit-area expanders.

## Accessibility
9. **Playground sidebar contrast** — year badges/metadata to full `muted-foreground`; disabled rows no longer stack two opacity dimmers (~30% visibility).
12. **About tooltips** — keyboard-focusable triggers, `role=tooltip` + `aria-describedby`, focus-visible ring, Escape dismiss.
19. **Go-to-slide overlay** — `aria-modal`, Tab trap, focus restore, and Escape now works while typing in the input.
20. **Lens cards unfocusable while invisible** during the deck entrance (`visibility: hidden` + `tabIndex -1` until revealed).

## States & performance
13. **Theme-aware article skeleton** for ISR fallback (replaces a hardcoded-gray spinner in dark mode; spinner itself now uses `currentColor`).
14. **Off-screen playground covers pause** their infinite CSS animations (continuous `useInView` + `animation-play-state`, `content-visibility: auto`). Verified: 7 off-screen paused, 4 visible running.

## Consistency
10. **Site-wide scrollbar hiding removed**; inner scrollbars tokenized (`--scrollbar-thumb`, `--dw-scrollbar-thumb`).
11. **PageSocial hover fill** composited on `transform: scale` instead of animating width/height.
15. **Easing tokens single-sourced** — duplicate definitions removed; `cubic-bezier(0.32,0.72,0,1)` ×62 and `(0.22,1,0.36,1)` ×49 replaced with `--ease-out-swift`/`--ease-out-smooth`. Promoting `--ease-out-snap` to `:root` also fixed the portal-rendered panel falling back to `ease`.
16. **Semantic z-index scale adopted** — `z-index: 9999` killed; lenses modal ladder is `--z-modal + 0..3`; scale documented.
17. **Presentation shadows consolidated** to one local `--shadow-overlay` (a global `--shadow-*` scale was deliberately skipped — it would collide with Tailwind v4's shadow namespace, the same bug class idea 1 fixed).
18. **One pill convention** — `--radius-pill: 9999px` replaces `999px`/`290486px`/`99px`.

## Verification
- `pnpm typecheck`, `eslint`, `prettier --check`, and `vitest` (37/37) all pass.
- Every change exercised on a live dev server via browser automation: computed-style assertions (token resolution, hit areas, focus traps, pause states, z-ladder) plus full before/after screenshot passes across About, Playground, Lenses (desktop + mobile panel/dialog), 404, design workbench, and the prompting presenter in light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)