### PR TITLE
fix(prompting): keep equation token chips readable in dark mode

### DIFF
--- a/components/wustep/prompting/PromptingPage.module.css
+++ b/components/wustep/prompting/PromptingPage.module.css
@@ -2411,6 +2411,20 @@
   color: var(--bg-color, #fff);
 }
 
+/* The generic `.dark-mode .token` override outranks the single-class kind
+   rules above, so the kinds restate their surfaces at equal specificity. */
+:global(.dark-mode) .token_agent,
+:global(.dark-mode) .token_input {
+  background: var(--pm-accent-soft, rgba(232, 122, 74, 0.13));
+  border-color: var(--pm-accent-line, rgba(232, 122, 74, 0.45));
+}
+
+:global(.dark-mode) .token_output {
+  background: var(--fg-color-6, rgba(255, 255, 255, 0.84));
+  border-color: transparent;
+  color: var(--bg-color, #0d0d0d);
+}
+
 .op {
   display: inline-block;
   padding: 0 4px;


### PR DESCRIPTION
## Summary
- The `.dark-mode .token` override (two classes) outranked the single-class `.token_agent` / `.token_input` / `.token_output` rules, so in dark mode the OUTPUT chip lost its light surface and rendered near-black text on a near-black chip.
- Restates the token-kind surfaces at matching specificity under `.dark-mode`: OUTPUT gets back its light background with dark ink, AGENT/INPUT get back their accent-soft backgrounds and accent borders.
- Light mode untouched; fix applies everywhere `Token` is reused (equation demo, recap).

## Test plan
- [ ] `/prompting/equation` in dark mode: OUTPUT is a light chip with dark text in both the compact and expanded equation lines
- [ ] AGENT/INPUT chips show the soft vermillion background/border in dark mode
- [ ] Light mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)