### PR TITLE
perf: fix brittle cache poisoning and split heavy client bundles

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,7 @@
       "name": "me-dev",
       "runtimeExecutable": "/bin/zsh",
       "runtimeArgs": ["-lc", "pnpm dev"],
-      "port": 3000,
+      "port": 6363,
       "autoPort": true
     }
   ]

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -16,10 +16,8 @@ import BodyClassName from 'react-body-classname'
 import {
   type ComponentOverrideFn,
   type NotionComponents,
-  NotionRenderer,
-  useNotionContext
+  NotionRenderer
 } from 'react-notion-x'
-import { EmbeddedTweet, TweetNotFound, TweetSkeleton } from 'react-tweet'
 
 import type * as types from '@/lib/types'
 import * as config from '@/lib/config'
@@ -143,20 +141,9 @@ const Modal = dynamic(
   }
 )
 
-function Tweet({ id }: { id: string }) {
-  const { recordMap } = useNotionContext()
-  // @wustep: id is a URL with a query string that includes spaceId, like [id]&spaceId=[spaceId]
-  const tweetId = id.split('&')[0]
-  const tweet = tweetId
-    ? (recordMap as types.ExtendedTweetRecordMap)?.tweets?.[tweetId]
-    : undefined
-
-  return (
-    <React.Suspense fallback={<TweetSkeleton />}>
-      {tweet ? <EmbeddedTweet tweet={tweet} /> : <TweetNotFound />}
-    </React.Suspense>
-  )
-}
+// Lazy like the other third-party embeds above: react-tweet only loads on the
+// handful of pages that actually contain a tweet.
+const Tweet = dynamic(() => import('./NotionTweet'), { ssr: false })
 
 const propertyLastEditedTimeValue: ComponentOverrideFn = (
   { block, pageHeader },

--- a/components/NotionTweet.tsx
+++ b/components/NotionTweet.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { useNotionContext } from 'react-notion-x'
+import { EmbeddedTweet, TweetNotFound, TweetSkeleton } from 'react-tweet'
+
+import type * as types from '@/lib/types'
+
+/**
+ * The react-tweet boundary, split out of NotionPage so it can be `dynamic()`d.
+ * Very few pages embed a tweet, but a static import put react-tweet (and its
+ * styles) in the shared bundle for every Notion page on the site.
+ */
+export default function NotionTweet({ id }: { id: string }) {
+  const { recordMap } = useNotionContext()
+  // @wustep: id is a URL with a query string that includes spaceId, like [id]&spaceId=[spaceId]
+  const tweetId = id.split('&')[0]
+  const tweet = tweetId
+    ? (recordMap as types.ExtendedTweetRecordMap)?.tweets?.[tweetId]
+    : undefined
+
+  return (
+    <React.Suspense fallback={<TweetSkeleton />}>
+      {tweet ? <EmbeddedTweet tweet={tweet} /> : <TweetNotFound />}
+    </React.Suspense>
+  )
+}

--- a/components/wustep/Comments.tsx
+++ b/components/wustep/Comments.tsx
@@ -34,7 +34,12 @@ export function Comments() {
     return () => {
       giscusScript.remove()
     }
-  })
+    // Only the theme affects the injected script. Without this dep array the
+    // effect re-ran on every render (dark-mode toggle, router change, any
+    // parent state change), each time removing and re-appending the script —
+    // re-fetching giscus.app/client.js and destroying the comments iframe,
+    // discarding whatever the reader had typed.
+  }, [isDarkMode])
 
   // If giscus is not configured, don't render anything
   if (!config.giscus) {

--- a/components/wustep/PlaygroundLayout.tsx
+++ b/components/wustep/PlaygroundLayout.tsx
@@ -209,7 +209,7 @@ function LayoutContent({
           {children}
         </div>
       ) : (
-        <div className='flex flex-1 flex-col gap-4 p-4 pt-8 bg-background'>
+        <div className='flex flex-1 flex-col gap-4 p-4 pt-8 pb-16 bg-background'>
           <div className='w-full max-w-4xl mx-auto'>
             <h1 className='text-4xl font-bold mb-8'>{title}</h1>
             {children}

--- a/lib/__tests__/tweet-cache.test.ts
+++ b/lib/__tests__/tweet-cache.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Hoisted mocks: stub the syndication client and the Redis-backed db so we
+// exercise only the caching semantics in lib/get-tweets.ts.
+const { getTweetDataMock, dbGetMock, dbSetMock } = vi.hoisted(() => ({
+  getTweetDataMock: vi.fn(),
+  dbGetMock: vi.fn(),
+  dbSetMock: vi.fn()
+}))
+
+vi.mock('react-tweet/api', () => ({ getTweet: getTweetDataMock }))
+vi.mock('../db', () => ({ dbGet: dbGetMock, dbSet: dbSetMock }))
+
+const { getTweet, getTweetsMap } = await import('../get-tweets')
+
+beforeEach(() => {
+  getTweetDataMock.mockReset()
+  dbGetMock.mockReset()
+  dbSetMock.mockReset()
+  // Default: cache read succeeds and misses.
+  dbGetMock.mockResolvedValue({ ok: true, value: undefined })
+  dbSetMock.mockResolvedValue(undefined)
+})
+
+describe('getTweet caching', () => {
+  it('dedupes concurrent calls for the same tweet into one fetch', async () => {
+    getTweetDataMock.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ id: '1' }), 5))
+    )
+
+    await Promise.all([getTweet('1'), getTweet('1')])
+
+    expect(getTweetDataMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a genuinely-missing tweet so it is not refetched', async () => {
+    // react-tweet resolves `undefined` for deleted/private/404 tweets — a
+    // durable fact worth caching.
+    getTweetDataMock.mockResolvedValue(undefined)
+
+    const first = await getTweet('2')
+    const second = await getTweet('2')
+
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    expect(getTweetDataMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a transient failure', async () => {
+    // A 429/5xx throws out of react-tweet. Caching that would blank a
+    // perfectly good embed for the life of the process.
+    getTweetDataMock.mockRejectedValueOnce(new Error('429'))
+    await expect(getTweet('3')).rejects.toThrow('429')
+
+    getTweetDataMock.mockResolvedValueOnce({ id: '3' })
+    await expect(getTweet('3')).resolves.toMatchObject({ id: '3' })
+
+    expect(getTweetDataMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not persist a transient failure to the shared db cache', async () => {
+    getTweetDataMock.mockRejectedValueOnce(new Error('503'))
+
+    await expect(getTweet('4')).rejects.toThrow('503')
+
+    expect(dbSetMock).not.toHaveBeenCalled()
+  })
+
+  it('skips the write-back when the cache read errored', async () => {
+    dbGetMock.mockResolvedValue({ ok: false })
+    getTweetDataMock.mockResolvedValue({ id: '5' })
+
+    await getTweet('5')
+
+    expect(dbSetMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getTweetsMap', () => {
+  it('contains a per-tweet failure instead of failing the page render', async () => {
+    getTweetDataMock.mockRejectedValue(new Error('boom'))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const recordMap = {
+      block: {
+        b1: {
+          value: {
+            id: 'b1',
+            type: 'tweet',
+            properties: { source: [['https://twitter.com/x/status/6']] }
+          }
+        }
+      },
+      collection: {},
+      collection_view: {},
+      notion_user: {},
+      signed_urls: {}
+    } as never
+
+    await expect(getTweetsMap(recordMap)).resolves.toBeUndefined()
+    expect((recordMap as { tweets?: unknown }).tweets).toEqual({ '6': null })
+  })
+})

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,6 +15,33 @@ if (isRedisEnabled) {
 export { db }
 
 /**
+ * The cache is an optimization, never a source of truth — so it must never be
+ * able to hold up a render. Keyv/Redis surfaces connection *errors*, but a
+ * genuinely hung socket just never settles, and these calls sit on the render
+ * path (getPreviewImageMap / getTweetsMap → getPage), so one unresponsive
+ * Redis could stall ISR for the route's full 60s maxDuration. Bound every
+ * call and fall back to treating it as a miss.
+ */
+const DB_TIMEOUT_MS = 1000
+
+const TIMED_OUT = Symbol('cache-timeout')
+
+function withTimeout<T>(
+  operation: Promise<T>,
+  label: string
+): Promise<T | typeof TIMED_OUT> {
+  return Promise.race([
+    operation,
+    new Promise<typeof TIMED_OUT>((resolve) =>
+      setTimeout(() => {
+        console.warn(`cache ${label} timed out after ${DB_TIMEOUT_MS}ms`)
+        resolve(TIMED_OUT)
+      }, DB_TIMEOUT_MS).unref?.()
+    )
+  ])
+}
+
+/**
  * Read from the cache, distinguishing a genuine miss (`ok: true`, no value)
  * from a backend error (`ok: false`). On a read error a caller can't tell
  * whether a good value already exists, so it shouldn't clobber it with a write.
@@ -23,7 +50,12 @@ export async function dbGet<T>(
   key: string
 ): Promise<{ ok: true; value: T | undefined } | { ok: false }> {
   try {
-    return { ok: true, value: (await db.get(key)) as T | undefined }
+    const value = await withTimeout(db.get(key), `read "${key}"`)
+    // A timeout is indistinguishable from a backend error for our purposes:
+    // we can't tell whether a good value exists, so report it as not-ok and
+    // let the caller skip the write-back rather than clobber.
+    if (value === TIMED_OUT) return { ok: false }
+    return { ok: true, value: value as T | undefined }
   } catch (err: unknown) {
     console.warn(`cache read error "${key}"`, getErrorMessage(err))
     return { ok: false }
@@ -33,7 +65,7 @@ export async function dbGet<T>(
 /** Write to the cache, swallowing (and logging) backend errors. */
 export async function dbSet<T>(key: string, value: T): Promise<void> {
   try {
-    await db.set(key, value)
+    await withTimeout(db.set(key, value), `write "${key}"`)
   } catch (err: unknown) {
     console.warn(`cache write error "${key}"`, getErrorMessage(err))
   }

--- a/lib/get-tweets.ts
+++ b/lib/get-tweets.ts
@@ -1,3 +1,4 @@
+import ExpiryMap from 'expiry-map'
 import { type ExtendedRecordMap } from 'notion-types'
 import { getPageTweetIds } from 'notion-utils'
 import pMap from 'p-map'
@@ -42,7 +43,15 @@ export async function getTweetsMap(
     await pMap(
       tweetIds,
       async (tweetId: string) => {
-        return [tweetId, await getTweet(tweetId)]
+        // Contain per-tweet failures here rather than in getTweetImpl, so a
+        // transient error stays uncached (see getTweetImpl) while still not
+        // failing the whole page render over one flaky embed.
+        try {
+          return [tweetId, await getTweet(tweetId)]
+        } catch (err: unknown) {
+          console.warn('failed to get tweet', tweetId, getErrorMessage(err))
+          return [tweetId, null]
+        }
       },
       {
         concurrency: 8
@@ -53,32 +62,52 @@ export async function getTweetsMap(
   ;(recordMap as ExtendedTweetRecordMap).tweets = tweetsMap
 }
 
+/**
+ * Fetch a single tweet, or `null` if it is genuinely gone.
+ *
+ * This deliberately does *not* catch. `react-tweet`'s `getTweet` distinguishes
+ * the two failure modes for us, and conflating them is what makes tweet
+ * caching brittle:
+ *
+ * - Deleted / private / 404 → resolves `undefined`. That's a durable fact, so
+ *   we normalize it to `null` and cache it (in-process and in Redis) as a
+ *   "known missing" hit.
+ * - Rate limit, 5xx, network error → throws. That's transient, so we let it
+ *   propagate: `pMemoize` never caches a rejection, and we never reach the
+ *   `dbSet` below. Previously both paths returned `null`, so a single 429 was
+ *   memoized for the life of the process *and* persisted to Redis with no TTL
+ *   — permanently blanking an embed that was perfectly fine.
+ *
+ * `getTweetsMap` is responsible for catching, so one flaky embed can't fail a
+ * whole page render.
+ */
 async function getTweetImpl(tweetId: string): Promise<any> {
   if (!tweetId) return null
 
   const cacheKey = `tweet:${tweetId}`
 
-  try {
-    // A cached `null` means "known missing" — keep it as a hit to avoid refetch.
-    const cached = await dbGet<Record<string, any> | null>(cacheKey)
-    if (cached.ok && (cached.value || cached.value === null)) {
-      return normalizeTweetEntities(cached.value)
-    }
-
-    const tweetData = normalizeTweetEntities(
-      (await getTweetData(tweetId)) || null
-    )
-
-    // Only write back when the read succeeded (don't clobber on a read error).
-    if (cached.ok) {
-      await dbSet(cacheKey, tweetData)
-    }
-
-    return tweetData
-  } catch (err: unknown) {
-    console.warn('failed to get tweet', tweetId, getErrorMessage(err))
-    return null
+  // A cached `null` means "known missing" — keep it as a hit to avoid refetch.
+  const cached = await dbGet<Record<string, any> | null>(cacheKey)
+  if (cached.ok && (cached.value || cached.value === null)) {
+    return normalizeTweetEntities(cached.value)
   }
+
+  const tweetData = normalizeTweetEntities(
+    (await getTweetData(tweetId)) || null
+  )
+
+  // Only write back when the read succeeded (don't clobber on a read error).
+  if (cached.ok) {
+    await dbSet(cacheKey, tweetData)
+  }
+
+  return tweetData
 }
 
-export const getTweet = pMemoize(getTweetImpl)
+// TTL-bounded so a long-lived server doesn't retain every tweet it has ever
+// rendered, and so a "known missing" verdict is eventually re-checked.
+const TWEET_CACHE_TTL_MS = 25 * 60 * 1000
+
+export const getTweet = pMemoize(getTweetImpl, {
+  cache: new ExpiryMap<string, any>(TWEET_CACHE_TTL_MS)
+})

--- a/lib/preview-images.ts
+++ b/lib/preview-images.ts
@@ -1,3 +1,4 @@
+import ExpiryMap from 'expiry-map'
 import ky from 'ky'
 import lqip from 'lqip-modern'
 import {
@@ -86,7 +87,19 @@ async function createPreviewImage(
   }
 }
 
-export const getPreviewImage = pMemoize(createPreviewImage)
+// Mirrors the caching strategy in ./notion.ts: pMemoize dedupes concurrent
+// calls for the same image, ExpiryMap bounds the cache so a long-lived server
+// process doesn't accumulate every image URL it has ever seen, and
+// `shouldCache` keeps failures out of the cache — otherwise one transient
+// fetch error would permanently strip an image's LQIP placeholder for the
+// life of the process.
+const PREVIEW_IMAGE_CACHE_TTL_MS = 25 * 60 * 1000
+
+export const getPreviewImage = pMemoize(createPreviewImage, {
+  cacheKey: ([, { cacheKey }]) => cacheKey,
+  cache: new ExpiryMap<string, PreviewImage | null>(PREVIEW_IMAGE_CACHE_TTL_MS),
+  shouldCache: (result) => result !== null
+})
 
 /**
  * Build a merged, null-free preview-image map across many record maps.

--- a/lib/search-notion.ts
+++ b/lib/search-notion.ts
@@ -5,7 +5,11 @@ import type * as types from './types'
 import { api } from './config'
 
 export const searchNotion = pMemoize(searchNotionImpl, {
-  cacheKey: (args) => args[0]?.query,
+  // Key on the whole params object, not just `query` — `ancestorIds`, filters
+  // and limit all change the result set, so keying on the query string alone
+  // let two structurally different searches collide and serve each other's
+  // results. Matches the server-side `search` in ./notion.ts.
+  cacheKey: (args) => JSON.stringify(args[0]),
   cache: new ExpiryMap(10_000)
 })
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 6363",
     "prebuild": "pnpm notion:index",
     "build": "next build",
     "start": "next start",

--- a/pages/api/social-image.tsx
+++ b/pages/api/social-image.tsx
@@ -163,7 +163,15 @@ export default async function OGImage(
           style: 'normal',
           weight: 700
         }
-      ]
+      ],
+      // OG images are hit repeatedly by crawlers and link unfurlers and change
+      // only when the page title/cover changes. Without a cache header every
+      // one of those hits was a fresh Notion fetch plus a full image render on
+      // a public, unauthenticated endpoint.
+      headers: {
+        'Cache-Control':
+          'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800'
+      }
     }
   )
 }

--- a/pages/playground/midi-visualizer.tsx
+++ b/pages/playground/midi-visualizer.tsx
@@ -1,5 +1,16 @@
-import { MidiVisualizer } from '@/components/wustep/MidiVisualizer'
+import dynamic from 'next/dynamic'
+
 import { PlaygroundLayout } from '@/components/wustep/PlaygroundLayout'
+
+// The visualizer pulls in Tone.js, which is by far the heaviest dependency on
+// the site and is useless until the user actually interacts with the keyboard.
+// Loading it lazily (and client-only — it needs Web Audio + canvas) keeps it
+// out of this page's initial JS.
+const MidiVisualizer = dynamic(
+  () =>
+    import('@/components/wustep/MidiVisualizer').then((m) => m.MidiVisualizer),
+  { ssr: false }
+)
 
 export default function PlaygroundMidiVisualizerPage() {
   return (

--- a/pages/site.tsx
+++ b/pages/site.tsx
@@ -13,7 +13,12 @@ export const getStaticProps = async () => {
   try {
     const props = await resolveNotionPage(domain)
 
-    return { props, revalidate: 10 }
+    // Roughly aligned with PAGE_CACHE_TTL_MS (25m) in lib/notion.ts. A shorter
+    // window doesn't actually buy freshness: `getPage` is memoized per server
+    // instance for 25m, so a warm instance regenerating every 10s just
+    // re-serves the same cached recordMap. All it bought was ISR churn and
+    // Notion rate-limit pressure on the site's hottest page.
+    return { props, revalidate: 1800 }
   } catch (err) {
     console.error('page error', domain, err)
 


### PR DESCRIPTION
Two themes: **caches that a single transient error could poison permanently**, and **heavy dependencies shipped to pages that never use them**.

## Caching

### Tweet cache poisoning (the brittle one)
`react-tweet`'s `fetchTweet` already distinguishes the two failure modes:

| Situation | Behavior |
|---|---|
| Deleted / private / 404 | resolves `undefined` — a **durable** fact |
| Rate limit, 5xx, network | **throws** — a **transient** fact |

`getTweetImpl` wrapped everything in `try/catch → return null`, collapsing them. That `null` was then:
1. memoized in p-memoize's **default unbounded `Map`** (no TTL, no max size) for the life of the process, and
2. persisted to **Redis with no TTL** — so a restart didn't fix it either.

Net effect: one 429 from X permanently blanked a perfectly healthy embed.

Now transient errors propagate — `pMemoize` never caches a rejection, and we never reach the `dbSet`. `getTweetsMap` catches per-tweet instead, so one flaky embed still can't fail a page render.

### Same pattern elsewhere
- **`lib/preview-images.ts`** — identical unbounded-`Map` + cached-`null`, with heavier base64 LQIP values. Added a TTL cache plus `shouldCache` to keep failures out.
- **`lib/db.ts`** — every Keyv/Redis call is now bounded by a 1s deadline. Keyv surfaces connection *errors*, but a genuinely hung socket never settles, and these calls sit on the render path (`getPreviewImageMap`/`getTweetsMap` → `getPage`), so one unresponsive Redis could stall ISR for the route's full 60s `maxDuration`.
- **`lib/search-notion.ts`** — cache key was `args[0]?.query`, ignoring `ancestorIds`, filters and `limit`. Two structurally different searches with the same query string collided and served each other's results. Now keys on the whole params object, matching the server-side `search`.

## Rendering & bundles

- **`Comments.tsx`** — the giscus `useEffect` had **no dependency array**. Every re-render (dark-mode toggle, router change, any parent state change) removed and re-appended the script tag, re-fetching `giscus.app/client.js` and destroying the comments iframe along with anything the reader had typed. Now `[isDarkMode]`.
- **`NotionPage.tsx`** — `react-tweet` was a static import on *every* Notion page despite almost none having a tweet. Moved behind `dynamic()` like the existing `Code`/`Collection`/`Equation`/`Pdf`/`Modal` embeds. Its **23.6KB** chunk is no longer in `/[pageId]`'s initial manifest.
- **`playground/midi-visualizer`** — Tone.js is useless until first play. Loading the visualizer via `dynamic(ssr:false)` moves its **263KB** chunk out of the page's initial JS.
- **`pages/site.tsx`** — `revalidate: 10` → `1800`. This is the subtle one: `getPage` is memoized per server instance for 25 minutes, so a warm instance regenerating every 10s was **re-serving the same cached recordMap**. The short window bought ISR churn and Notion rate-limit pressure on the hottest page, not freshness.
- **`api/social-image`** — the OG endpoint set no `Cache-Control` at all, so every crawler and link-unfurler hit was a fresh Notion fetch plus a full image render on a public, unauthenticated endpoint.

## Testing
`pnpm typecheck`, `eslint`, `prettier --check`, and `vitest` (43 tests) all pass; `next build` succeeds. Added `lib/__tests__/tweet-cache.test.ts` (6 tests) covering the transient-vs-durable distinction — the "does not cache a transient failure" case fails against the old code.

## Deliberately not included
Larger refactors surfaced during the audit, worth separate PRs:
- `MidiVisualizer` runs its `requestAnimationFrame` loop unconditionally at 60fps even when idle/off-screen, and `setPlaybackTime` re-renders the 1400-line component every frame during playback.
- `LensesIllustrationLab` does layout reads + `matchMedia` + `setState` inside a scroll rAF (read/write thrash); its `resize` listener is missing `passive: true`.
- `katex` + `prismjs` CSS load globally on every route, including ones with no Notion content.
- `matter-js` appears to be an unused dependency.
- `[pageId]` uses `fallback: true` rather than `'blocking'`, which serves crawlers an empty shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
