### PR TITLE
fix(images): stop breaking Notion file.notion.com images

### DIFF
--- a/lib/__tests__/map-image-url.test.ts
+++ b/lib/__tests__/map-image-url.test.ts
@@ -1,0 +1,49 @@
+import { type Block } from 'notion-types'
+import { describe, expect, it } from 'vitest'
+
+import { isNotionFileHostUrl, mapImageUrl } from '../map-image-url'
+
+const block = { id: '1285cb08-cf2c-806c-83d9-ce2bbaaa663f' } as Block
+
+describe('isNotionFileHostUrl', () => {
+  it('matches file.notion.com', () => {
+    expect(
+      isNotionFileHostUrl(
+        'https://file.notion.com/f/f/abc/image.png?table=block&id=1'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match the notion.so image proxy', () => {
+    expect(
+      isNotionFileHostUrl(
+        'https://www.notion.so/image/https%3A%2F%2Ffile.notion.com%2Ff%2Fimage.png'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('mapImageUrl', () => {
+  it('does not wrap file.notion.com URLs in the notion.so image proxy', () => {
+    const url =
+      'https://file.notion.com/f/f/30725683-e071-41f1-988d-e6e6fa72abd8/07ac880a-4a18-4935-b277-a439c76ce80c/image.png?table=block&id=1285cb08-cf2c-806c-83d9-ce2bbaaa663f&spaceId=30725683'
+
+    expect(mapImageUrl(url, block)).toBe(url)
+  })
+
+  it('still proxies S3-hosted Notion files through notion.so/image', () => {
+    const url =
+      'https://prod-files-secure.s3.us-west-2.amazonaws.com/30725683-e071-41f1-988d-e6e6fa72abd8/c20d3edd-9bce-47ab-9643-d3bae6cdd143/photo.png'
+
+    const mapped = mapImageUrl(url, block)
+    expect(mapped).toContain('https://www.notion.so/image/')
+    expect(mapped).toContain(encodeURIComponent(url))
+  })
+
+  it('leaves Unsplash URLs alone', () => {
+    const url =
+      'https://images.unsplash.com/photo-1620121478247-ec786b9be2fa?ixlib=rb-4.0.3'
+
+    expect(mapImageUrl(url, block)).toBe(url)
+  })
+})

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -3,8 +3,31 @@ import { defaultMapImageUrl } from 'notion-utils'
 
 import { defaultPageCover, defaultPageIcon } from './config'
 
+/**
+ * Notion file hosts that `www.notion.so/image/...` cannot proxy.
+ * Wrapping these produces "Source image is unreachable" (HTTP 404) from the
+ * image optimizer. Pass the signed file URL through instead.
+ */
+const NOTION_FILE_HOSTS = new Set([
+  'file.notion.com',
+  'file.notion.so',
+  'img.notionusercontent.com'
+])
+
+export const isNotionFileHostUrl = (url: string): boolean => {
+  try {
+    return NOTION_FILE_HOSTS.has(new URL(url).hostname)
+  } catch {
+    return false
+  }
+}
+
 export const mapImageUrl = (url: string | undefined, block: Block) => {
   if (url === defaultPageCover || url === defaultPageIcon) {
+    return url
+  }
+
+  if (url && isNotionFileHostUrl(url)) {
     return url
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -25,11 +25,16 @@ export default withBundleAnalyzer({
     remotePatterns: [
       { protocol: 'https', hostname: 'www.notion.so' },
       { protocol: 'https', hostname: 'notion.so' },
+      { protocol: 'https', hostname: 'file.notion.com' },
+      { protocol: 'https', hostname: 'file.notion.so' },
+      { protocol: 'https', hostname: 'img.notionusercontent.com' },
       { protocol: 'https', hostname: 'images.unsplash.com' },
       { protocol: 'https', hostname: 'abs.twimg.com' },
       { protocol: 'https', hostname: 'pbs.twimg.com' },
       { protocol: 'https', hostname: 's3.us-west-2.amazonaws.com' }
     ],
+    // Keep optimized copies around after Notion file URLs expire (~1h).
+    minimumCacheTTL: 60 * 60 * 24,
     formats: ['image/avif', 'image/webp'],
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;"

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -42,7 +42,9 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   try {
     const props = await resolveNotionPage(domain, normalizedPageId)
 
-    return { props, revalidate: 86_400 }
+    // Notion-hosted file.notion.com URLs expire in ~1h. Rebuild often enough
+    // that next/image can fetch a still-valid signed URL.
+    return { props, revalidate: 1800 }
   } catch (err: unknown) {
     console.error('page error', domain, requestedPageId, err)
 


### PR DESCRIPTION
## Summary
Post images on wustep.me (e.g. `/headspace`) 404'd because Notion now serves some files from `file.notion.com`. Wrapping those signed URLs in `www.notion.so/image/...` returns "Source image is unreachable" once they expire (~1h). S3-hosted Notion files still work through that proxy.

## Changes
- Pass `file.notion.com` / `file.notion.so` / `img.notionusercontent.com` URLs through `mapImageUrl` instead of proxying them
- Allow those hosts in `next.config.js` `images.remotePatterns`, and keep optimized copies for 24h
- Revalidate Notion pages every 30 minutes so HTML still has a valid signed URL when next/image fetches

## Test plan
- [x] `vitest`: 48 tests, including new `map-image-url` cases
- [x] Local `next dev` on :6363: a live `file.notion.com` URL from `/headspace` returns 200 through `/_next/image`
- [ ] After deploy, confirm `/headspace` images load (the one that 404'd on production)