### PR TITLE
fix: Highlighty 404 and /oct-25 images

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -22,7 +22,7 @@ import {
 import type * as types from '@/lib/types'
 import * as config from '@/lib/config'
 import { getExternalUrlMap } from '@/lib/get-external-url-map'
-import { mapImageUrl } from '@/lib/map-image-url'
+import { mapImageUrl, shouldUnoptimizeNotionImage } from '@/lib/map-image-url'
 import { getCanonicalPageUrl, mapPageUrl } from '@/lib/map-page-url'
 import { searchNotion } from '@/lib/search-notion'
 import { useDarkMode } from '@/lib/use-dark-mode'
@@ -40,6 +40,16 @@ import { PageHead } from './PageHead'
 import styles from './styles.module.css'
 import { Comments } from './wustep/Comments'
 import { WustepFooter } from './wustep/WustepFooter'
+
+function NotionLegacyImage(props: React.ComponentProps<typeof Image>) {
+  const src = typeof props.src === 'string' ? props.src : undefined
+  return (
+    <Image
+      {...props}
+      unoptimized={props.unoptimized || shouldUnoptimizeNotionImage(src)}
+    />
+  )
+}
 
 // -----------------------------------------------------------------------------
 // dynamic imports for optional components
@@ -259,7 +269,7 @@ export function NotionPage({
 
   const components = React.useMemo<Partial<NotionComponents>>(
     () => ({
-      nextLegacyImage: Image,
+      nextLegacyImage: NotionLegacyImage,
       nextLink: Link,
       Code,
       Collection,

--- a/docs/images.md
+++ b/docs/images.md
@@ -4,27 +4,15 @@ Three somewhat-tangled concerns: **preview images (LQIP)**, **social/OG images**
 
 ## Signed-URL expiration fix
 
-Notion serves user-uploaded images from S3 via short-lived signed URLs (`*.amazonaws.com`). If we cache a record map that contains these URLs, the URLs expire and images 404 until the next ISR revalidation.
+Notion serves user-uploaded images via short-lived signed URLs (`*.amazonaws.com`, and now `file.notion.com`). If we cache a record map that contains these URLs, the URLs expire (~1h) and images 404 until the next ISR revalidation. Passing `file.notion.com` through `next/image` (PR #21) also leaves HEIC uploads as raw `.heic` files, which most browsers cannot display.
 
 ### Fix
 
-[`lib/notion.ts`](../lib/notion.ts) strips `.amazonaws.com` entries from `recordMap.signed_urls` after every `getPage` fetch:
+[`lib/notion.ts`](../lib/notion.ts) drops expiring signed hosts from `recordMap.signed_urls` after every `getPage` fetch (see [`lib/signed-file-urls.ts`](../lib/signed-file-urls.ts)). `react-notion-x` then falls back to the unsigned `attachment:` / S3 source, which [`mapImageUrl`](../lib/map-image-url.ts) wraps in Notion's image proxy. That proxy stays valid and converts HEIC → JPEG.
 
-```ts
-if (recordMap && recordMap.signed_urls) {
-  const signedUrls = recordMap.signed_urls
-  const newSignedUrls: Record<string, string> = {}
-  for (const url in signedUrls) {
-    if (signedUrls[url] && signedUrls[url].includes('.amazonaws.com')) {
-      continue  // drop it
-    }
-    newSignedUrls[url] = signedUrls[url]!
-  }
-  recordMap.signed_urls = newSignedUrls
-}
-```
+`www.notion.so/image` now 302s to `img.notionusercontent.com`. `next/image` treats that redirect as an invalid upstream response, so Notion-proxied (and HEIC) srcs are rendered `unoptimized` and the browser follows the redirect.
 
-`react-notion-x` then falls back to going through Notion's image proxy instead of the stale S3 URL. Credit to the upstream issue: [transitive-bullshit/nextjs-notion-starter-kit#279](https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/279#issuecomment-1245467818).
+Credit to the upstream S3-expiry approach: [transitive-bullshit/nextjs-notion-starter-kit#279](https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/279#issuecomment-1245467818).
 
 ## Preview images (LQIP)
 

--- a/lib/__tests__/get-canonical-page-id.test.ts
+++ b/lib/__tests__/get-canonical-page-id.test.ts
@@ -5,11 +5,50 @@ import { getCanonicalPageId } from '../get-canonical-page-id'
 
 const emptyRecordMap = { block: {} } as unknown as ExtendedRecordMap
 
+const pageId = '2bc5cb08-cf2c-810b-83af-c01fde10aefa'
+const collectionId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+const slugRecordMap = {
+  block: {
+    [pageId]: {
+      role: 'reader',
+      value: {
+        id: pageId,
+        type: 'page',
+        parent_table: 'collection',
+        parent_id: collectionId,
+        properties: {
+          title: [['Rapid Prototyping: Highlighty']],
+          slug: [['rapid-prototyping-highlighty']]
+        }
+      }
+    }
+  },
+  collection: {
+    [collectionId]: {
+      role: 'reader',
+      value: {
+        id: collectionId,
+        schema: {
+          title: { name: 'Name', type: 'title' },
+          slug: { name: 'Slug', type: 'text' }
+        }
+      }
+    }
+  }
+} as unknown as ExtendedRecordMap
+
 describe('getCanonicalPageId', () => {
   it('returns undefined for an unparseable page id', () => {
     expect(getCanonicalPageId('', emptyRecordMap)).toBeUndefined()
     expect(
       getCanonicalPageId('not-a-notion-id', emptyRecordMap)
     ).toBeUndefined()
+  })
+
+  it('uses the Slug collection property', () => {
+    expect(getCanonicalPageId(pageId, slugRecordMap, { uuid: false })).toBe(
+      'rapid-prototyping-highlighty'
+    )
   })
 })

--- a/lib/__tests__/get-external-url-map.test.ts
+++ b/lib/__tests__/get-external-url-map.test.ts
@@ -1,0 +1,68 @@
+import { type ExtendedRecordMap } from 'notion-types'
+import { describe, expect, it } from 'vitest'
+
+import { getExternalUrlMap } from '../get-external-url-map'
+
+const collectionId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const pageId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+function recordMap(opts: {
+  external: boolean
+  url?: string
+}): ExtendedRecordMap {
+  return {
+    block: {
+      [pageId]: {
+        role: 'reader',
+        value: {
+          id: pageId,
+          type: 'page',
+          parent_table: 'collection',
+          parent_id: collectionId,
+          properties: {
+            title: [['Dashboards at Notion']],
+            external: [[opts.external ? 'Yes' : 'No']],
+            ...(opts.url ? { exturl: [[opts.url]] } : {})
+          }
+        }
+      }
+    },
+    collection: {
+      [collectionId]: {
+        role: 'reader',
+        value: {
+          id: collectionId,
+          schema: {
+            title: { name: 'Name', type: 'title' },
+            external: { name: 'External', type: 'checkbox' },
+            exturl: { name: 'External URL', type: 'url' }
+          }
+        }
+      }
+    }
+  } as unknown as ExtendedRecordMap
+}
+
+describe('getExternalUrlMap', () => {
+  it('maps a page with External + External URL', () => {
+    const map = getExternalUrlMap(
+      recordMap({
+        external: true,
+        url: 'https://x.com/wustep/article/1'
+      })
+    )
+    expect(map.get('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')).toBe(
+      'https://x.com/wustep/article/1'
+    )
+  })
+
+  it('skips pages that are not marked External', () => {
+    const map = getExternalUrlMap(
+      recordMap({
+        external: false,
+        url: 'https://example.com'
+      })
+    )
+    expect(map.size).toBe(0)
+  })
+})

--- a/lib/__tests__/map-image-url.test.ts
+++ b/lib/__tests__/map-image-url.test.ts
@@ -1,34 +1,27 @@
 import { type Block } from 'notion-types'
 import { describe, expect, it } from 'vitest'
 
-import { isNotionFileHostUrl, mapImageUrl } from '../map-image-url'
+import { mapImageUrl } from '../map-image-url'
 
 const block = { id: '1285cb08-cf2c-806c-83d9-ce2bbaaa663f' } as Block
 
-describe('isNotionFileHostUrl', () => {
-  it('matches file.notion.com', () => {
-    expect(
-      isNotionFileHostUrl(
-        'https://file.notion.com/f/f/abc/image.png?table=block&id=1'
-      )
-    ).toBe(true)
-  })
-
-  it('does not match the notion.so image proxy', () => {
-    expect(
-      isNotionFileHostUrl(
-        'https://www.notion.so/image/https%3A%2F%2Ffile.notion.com%2Ff%2Fimage.png'
-      )
-    ).toBe(false)
-  })
-})
-
 describe('mapImageUrl', () => {
-  it('does not wrap file.notion.com URLs in the notion.so image proxy', () => {
+  it('wraps file.notion.com URLs in the notion.so image proxy', () => {
     const url =
       'https://file.notion.com/f/f/30725683-e071-41f1-988d-e6e6fa72abd8/07ac880a-4a18-4935-b277-a439c76ce80c/image.png?table=block&id=1285cb08-cf2c-806c-83d9-ce2bbaaa663f&spaceId=30725683'
 
-    expect(mapImageUrl(url, block)).toBe(url)
+    const mapped = mapImageUrl(url, block)
+    expect(mapped).toContain('https://www.notion.so/image/')
+    expect(mapped).toContain(encodeURIComponent(url))
+  })
+
+  it('wraps HEIC file.notion.com URLs so the proxy can convert them', () => {
+    const url =
+      'https://file.notion.com/f/f/30725683-e071-41f1-988d-e6e6fa72abd8/d25020a5-cf96-4eee-bdca-e58e60fd4564/photo.heic?table=block&id=1285cb08-cf2c-806c-83d9-ce2bbaaa663f'
+
+    const mapped = mapImageUrl(url, block)
+    expect(mapped).toContain('https://www.notion.so/image/')
+    expect(mapped).toContain('.heic')
   })
 
   it('still proxies S3-hosted Notion files through notion.so/image', () => {

--- a/lib/__tests__/map-image-url.test.ts
+++ b/lib/__tests__/map-image-url.test.ts
@@ -1,7 +1,7 @@
 import { type Block } from 'notion-types'
 import { describe, expect, it } from 'vitest'
 
-import { mapImageUrl } from '../map-image-url'
+import { mapImageUrl, shouldUnoptimizeNotionImage } from '../map-image-url'
 
 const block = { id: '1285cb08-cf2c-806c-83d9-ce2bbaaa663f' } as Block
 
@@ -33,10 +33,46 @@ describe('mapImageUrl', () => {
     expect(mapped).toContain(encodeURIComponent(url))
   })
 
+  it('wraps attachment: sources (current Notion upload format) in the proxy', () => {
+    const url =
+      'attachment:d25020a5-cf96-4eee-bdca-e58e60fd4564:EADC0DE2-FEA6-4356-A7ED-52AEB8952AD1.heic'
+
+    const mapped = mapImageUrl(url, block)
+    expect(mapped).toContain('https://www.notion.so/image/')
+    expect(mapped).toContain(encodeURIComponent(url))
+    expect(mapped).toContain('id=1285cb08-cf2c-806c-83d9-ce2bbaaa663f')
+  })
+
   it('leaves Unsplash URLs alone', () => {
     const url =
       'https://images.unsplash.com/photo-1620121478247-ec786b9be2fa?ixlib=rb-4.0.3'
 
     expect(mapImageUrl(url, block)).toBe(url)
+  })
+})
+
+describe('shouldUnoptimizeNotionImage', () => {
+  it('unoptimizes Notion image-proxy URLs', () => {
+    expect(
+      shouldUnoptimizeNotionImage(
+        'https://www.notion.so/image/attachment%3Aabc%3Aphoto.heic?table=block&id=1'
+      )
+    ).toBe(true)
+  })
+
+  it('unoptimizes raw HEIC sources that next/image cannot decode', () => {
+    expect(
+      shouldUnoptimizeNotionImage(
+        'https://file.notion.com/f/f/abc/photo.heic?table=block&id=1'
+      )
+    ).toBe(true)
+  })
+
+  it('leaves Unsplash on the optimizer', () => {
+    expect(
+      shouldUnoptimizeNotionImage(
+        'https://images.unsplash.com/photo-1620121478247-ec786b9be2fa'
+      )
+    ).toBe(false)
   })
 })

--- a/lib/__tests__/notion-cache.test.ts
+++ b/lib/__tests__/notion-cache.test.ts
@@ -58,6 +58,22 @@ describe('getPage caching', () => {
   // asserted here — this suite covers our wrapper: dedup, cache hits, and
   // that rejections aren't cached.
 
+  it('drops expiring file.notion.com and S3 signed URLs', async () => {
+    getPageMock.mockResolvedValue({
+      block: {},
+      signed_urls: {
+        a: 'https://file.notion.com/f/f/x/image.png?signature=1',
+        b: 'https://cdn.example.com/ok.png',
+        c: 'https://prod-files-secure.s3.us-west-2.amazonaws.com/x/y.png'
+      }
+    })
+
+    const page = await getPage('signed-urls')
+    expect(page.signed_urls).toEqual({
+      b: 'https://cdn.example.com/ok.png'
+    })
+  })
+
   it('does not cache a rejected fetch', async () => {
     getPageMock.mockRejectedValueOnce(new Error('boom'))
     await expect(getPage('flaky')).rejects.toThrow('boom')

--- a/lib/__tests__/page-slug.test.ts
+++ b/lib/__tests__/page-slug.test.ts
@@ -1,0 +1,106 @@
+import { type Block, type ExtendedRecordMap } from 'notion-types'
+import { describe, expect, it } from 'vitest'
+
+import { collectPublicPageSlugs, getPageSlug, slugifyTitle } from '../page-slug'
+
+const collectionId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const publicPageId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+const hiddenPageId = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+const privatePageId = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+
+function collectionRecordMap(): ExtendedRecordMap {
+  return {
+    block: {
+      [publicPageId]: {
+        role: 'reader',
+        value: {
+          id: publicPageId,
+          type: 'page',
+          parent_table: 'collection',
+          parent_id: collectionId,
+          properties: {
+            title: [['Rapid Prototyping: Highlighty']],
+            slug: [['rapid-prototyping-highlighty']],
+            public: [['Yes']]
+          }
+        }
+      },
+      [hiddenPageId]: {
+        role: 'reader',
+        value: {
+          id: hiddenPageId,
+          type: 'page',
+          parent_table: 'collection',
+          parent_id: collectionId,
+          properties: {
+            title: [['Books, Audiobooks, and Podcasts']],
+            slug: [['books-podcasts']],
+            public: [['Yes']]
+          }
+        }
+      },
+      [privatePageId]: {
+        role: 'reader',
+        value: {
+          id: privatePageId,
+          type: 'page',
+          parent_table: 'collection',
+          parent_id: collectionId,
+          properties: {
+            title: [['Secret draft']],
+            slug: [['secret-draft']],
+            public: [['No']]
+          }
+        }
+      }
+    },
+    collection: {
+      [collectionId]: {
+        role: 'reader',
+        value: {
+          id: collectionId,
+          schema: {
+            title: { name: 'Name', type: 'title' },
+            slug: { name: 'Slug', type: 'text' },
+            public: { name: 'Public', type: 'checkbox' }
+          }
+        }
+      }
+    }
+  } as unknown as ExtendedRecordMap
+}
+
+describe('slugifyTitle', () => {
+  it('kebab-cases a title', () => {
+    expect(slugifyTitle('Rapid Prototyping: Highlighty')).toBe(
+      'rapid-prototyping-highlighty'
+    )
+  })
+})
+
+describe('getPageSlug', () => {
+  const recordMap = collectionRecordMap()
+
+  it('prefers the Slug property over the title', () => {
+    const block = recordMap.block[publicPageId]!.value as Block
+    expect(getPageSlug(block, recordMap)).toBe('rapid-prototyping-highlighty')
+  })
+
+  it('falls back to a title slug when Slug is empty', () => {
+    const recordMapWithoutSlug = collectionRecordMap()
+    const block = recordMapWithoutSlug.block[publicPageId]!.value as Block
+    delete block.properties!.slug
+    expect(getPageSlug(block, recordMapWithoutSlug)).toBe(
+      'rapid-prototyping-highlighty'
+    )
+  })
+})
+
+describe('collectPublicPageSlugs', () => {
+  it('includes public collection pages and skips private ones', () => {
+    const map = collectPublicPageSlugs(collectionRecordMap())
+    expect(map['rapid-prototyping-highlighty']).toBe(publicPageId)
+    expect(map['books-podcasts']).toBe(hiddenPageId)
+    expect(map['secret-draft']).toBeUndefined()
+  })
+})

--- a/lib/__tests__/posts-collection.test.ts
+++ b/lib/__tests__/posts-collection.test.ts
@@ -1,0 +1,28 @@
+import { type CollectionInstance } from 'notion-types'
+import { describe, expect, it } from 'vitest'
+
+import { getCollectionBlockIds } from '../posts-collection'
+
+describe('getCollectionBlockIds', () => {
+  it('reads blockIds from the top-level result', () => {
+    expect(
+      getCollectionBlockIds({
+        result: { blockIds: ['a', 'b'] }
+      } as CollectionInstance)
+    ).toEqual(['a', 'b'])
+  })
+
+  it('falls back to collection_group_results', () => {
+    expect(
+      getCollectionBlockIds({
+        result: { collection_group_results: { blockIds: ['c'] } }
+      } as CollectionInstance)
+    ).toEqual(['c'])
+  })
+
+  it('returns an empty list when nothing is present', () => {
+    expect(getCollectionBlockIds({ result: {} } as CollectionInstance)).toEqual(
+      []
+    )
+  })
+})

--- a/lib/__tests__/resolve-page-id.test.ts
+++ b/lib/__tests__/resolve-page-id.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { lookupSlug, resolvePageIdFromMaps } from '../resolve-page-id'
+
+const maps = {
+  pageUrlOverrides: {
+    writing: '3415cb08cf2c80128c06eb41ddf69c79'
+  },
+  pageUrlAdditions: {
+    old: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  },
+  canonicalPageMap: {
+    highlighty: '2bc5cb08-cf2c-81cd-a0be-ce79763f25db',
+    'oct-25': '2bc5cb08-cf2c-81a9-90cf-df278a05d778'
+  }
+}
+
+describe('resolvePageIdFromMaps', () => {
+  it('resolves a raw Notion id', () => {
+    expect(
+      resolvePageIdFromMaps('2bc5cb08cf2c81cda0bece79763f25db', maps)
+    ).toBe('2bc5cb08-cf2c-81cd-a0be-ce79763f25db')
+  })
+
+  it('resolves pageUrlOverrides before the committed index', () => {
+    expect(resolvePageIdFromMaps('writing', maps)).toBe(
+      '3415cb08-cf2c-8012-8c06-eb41ddf69c79'
+    )
+  })
+
+  it('resolves slugs from the committed index', () => {
+    expect(resolvePageIdFromMaps('oct-25', maps)).toBe(
+      '2bc5cb08-cf2c-81a9-90cf-df278a05d778'
+    )
+  })
+
+  it('returns undefined for an unknown slug', () => {
+    expect(resolvePageIdFromMaps('rapid-prototyping-highlighty', maps)).toBe(
+      undefined
+    )
+  })
+})
+
+describe('lookupSlug', () => {
+  it('finds a slug in a collection-derived map', () => {
+    expect(
+      lookupSlug('rapid-prototyping-highlighty', {
+        'rapid-prototyping-highlighty': '2bc5cb08-cf2c-810b-83af-c01fde10aefa'
+      })
+    ).toBe('2bc5cb08-cf2c-810b-83af-c01fde10aefa')
+  })
+})

--- a/lib/__tests__/signed-file-urls.test.ts
+++ b/lib/__tests__/signed-file-urls.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterSignedUrls, isExpiringSignedFileUrl } from '../signed-file-urls'
+
+describe('isExpiringSignedFileUrl', () => {
+  it('matches file.notion.com', () => {
+    expect(
+      isExpiringSignedFileUrl(
+        'https://file.notion.com/f/f/abc/image.png?signature=1'
+      )
+    ).toBe(true)
+  })
+
+  it('matches S3-hosted Notion files', () => {
+    expect(
+      isExpiringSignedFileUrl(
+        'https://prod-files-secure.s3.us-west-2.amazonaws.com/abc/photo.png'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match Unsplash', () => {
+    expect(isExpiringSignedFileUrl('https://images.unsplash.com/photo-1')).toBe(
+      false
+    )
+  })
+})
+
+describe('filterSignedUrls', () => {
+  it('drops expiring hosts and keeps others', () => {
+    expect(
+      filterSignedUrls({
+        a: 'https://file.notion.com/f/f/x/image.png?signature=1',
+        b: 'https://cdn.example.com/ok.png',
+        c: 'https://prod-files-secure.s3.us-west-2.amazonaws.com/x/y.png'
+      })
+    ).toEqual({
+      b: 'https://cdn.example.com/ok.png'
+    })
+  })
+})

--- a/lib/generated/notion-index.json
+++ b/lib/generated/notion-index.json
@@ -4,6 +4,7 @@
     "advice-students": "2bc5cb08-cf2c-810c-aaeb-d6f828f3cfed",
     "april-25": "2bc5cb08-cf2c-8195-96e5-f02300629485",
     "bomberman": "2bc5cb08-cf2c-81f6-8f3d-fe0be9a89926",
+    "books-podcasts": "2bc5cb08-cf2c-81d4-afaf-cdb999482e69",
     "chorus": "2bc5cb08-cf2c-81db-abf3-e84ef158ce69",
     "cs-knowledge-graph": "2bc5cb08-cf2c-8162-992f-c8b2caad04e6",
     "dashboards": "3275cb08-cf2c-802e-8a55-ce05a7b8e37d",
@@ -21,6 +22,7 @@
     "on-music-improvisation": "2bc5cb08-cf2c-8175-b795-f3c012c88a70",
     "on-play": "2bc5cb08-cf2c-81c5-886e-c3a8b24b7f31",
     "philosophy": "2bc5cb08-cf2c-810d-a563-fe465ac36fad",
+    "rapid-prototyping-highlighty": "2bc5cb08-cf2c-810b-83af-c01fde10aefa",
     "shadbook": "2bc5cb08-cf2c-8119-b506-ec80fcbb2476",
     "so-long-meta": "2bc5cb08-cf2c-811c-9493-c7385a85d9cb",
     "spot-it": "2cb5cb08-cf2c-80b6-bde5-cdf0171e3e30",
@@ -31,6 +33,7 @@
     "updates": "2bc5cb08-cf2c-8036-a1e3-cddcb2c61d97",
     "vulnerability": "2bc5cb08-cf2c-815d-9f16-f0681ed9765d",
     "welcome": "2bc5cb08-cf2c-816d-b36f-cd90e532cd9a",
-    "wustep-me": "2bc5cb08-cf2c-81a3-9c73-d70cf9cd49cf"
+    "wustep-me": "2bc5cb08-cf2c-81a3-9c73-d70cf9cd49cf",
+    "wustep-me-ghost": "2bc5cb08-cf2c-8131-b2a7-f3714271d549"
   }
 }

--- a/lib/get-canonical-page-id.ts
+++ b/lib/get-canonical-page-id.ts
@@ -1,6 +1,8 @@
 import { type ExtendedRecordMap } from 'notion-types'
 import {
+  getBlockValue,
   getCanonicalPageId as getCanonicalPageIdImpl,
+  getPageProperty,
   parsePageId
 } from 'notion-utils'
 
@@ -19,11 +21,26 @@ export function getCanonicalPageId(
   const override = inversePageUrlOverrides[cleanPageId]
   if (override) {
     return override
-  } else {
-    return (
-      getCanonicalPageIdImpl(pageId, recordMap, {
-        uuid
-      }) ?? undefined
-    )
   }
+
+  // Prefer the collection `Slug` property when the block is present. The
+  // writing index and RSS feed use the same field; falling through to
+  // notion-utils still slugifies the title if Slug is empty.
+  const uuidPageId = parsePageId(pageId, { uuid: true })
+  const block =
+    (uuidPageId && getBlockValue(recordMap.block?.[uuidPageId])) ||
+    getBlockValue(recordMap.block?.[pageId])
+  const explicitSlug = block
+    ? getPageProperty<string>('Slug', block, recordMap)?.trim()
+    : undefined
+  if (explicitSlug) {
+    const slug = explicitSlug.replace(/^\/+/, '')
+    return uuid ? `${slug}-${cleanPageId}` : slug
+  }
+
+  return (
+    getCanonicalPageIdImpl(pageId, recordMap, {
+      uuid
+    }) ?? undefined
+  )
 }

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -10,6 +10,7 @@ import * as config from './config'
 import { includeNotionIdInUrls } from './config'
 import { getCanonicalPageId } from './get-canonical-page-id'
 import { buildNotion } from './notion-api'
+import { collectPublicPageSlugs } from './page-slug'
 
 const uuid = !!includeNotionIdInUrls
 
@@ -102,6 +103,29 @@ async function getAllPagesImpl(
     },
     {}
   )
+
+  // Home collection views filter out "Hide from home". Override pages like
+  // /writing still list those public posts, so merge their slugs into the
+  // index or the cards 404.
+  for (const overridePageId of new Set(
+    Object.values(config.pageUrlOverrides)
+  )) {
+    try {
+      const recordMap = await getPage(overridePageId)
+      const extra = collectPublicPageSlugs(recordMap)
+      for (const [slug, pageId] of Object.entries(extra)) {
+        if (!canonicalPageMap[slug]) {
+          canonicalPageMap[slug] = pageId
+        }
+      }
+    } catch (err) {
+      console.warn(
+        'failed to index override page collections',
+        overridePageId,
+        err
+      )
+    }
+  }
 
   return {
     pageMap,

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -10,3 +10,22 @@ export const mapImageUrl = (url: string | undefined, block: Block) => {
 
   return defaultMapImageUrl(url, block)
 }
+
+/**
+ * `www.notion.so/image` now 302s to `img.notionusercontent.com`. next/image
+ * treats that redirect as an invalid upstream response, so those srcs must
+ * skip the optimizer and let the browser follow the redirect.
+ */
+export function shouldUnoptimizeNotionImage(
+  src: string | undefined | null
+): boolean {
+  if (!src) {
+    return false
+  }
+
+  return (
+    src.includes('notion.so/image') ||
+    src.includes('attachment:') ||
+    /\.heic(?:$|[?#])/i.test(src)
+  )
+}

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -3,31 +3,8 @@ import { defaultMapImageUrl } from 'notion-utils'
 
 import { defaultPageCover, defaultPageIcon } from './config'
 
-/**
- * Notion file hosts that `www.notion.so/image/...` cannot proxy.
- * Wrapping these produces "Source image is unreachable" (HTTP 404) from the
- * image optimizer. Pass the signed file URL through instead.
- */
-const NOTION_FILE_HOSTS = new Set([
-  'file.notion.com',
-  'file.notion.so',
-  'img.notionusercontent.com'
-])
-
-export const isNotionFileHostUrl = (url: string): boolean => {
-  try {
-    return NOTION_FILE_HOSTS.has(new URL(url).hostname)
-  } catch {
-    return false
-  }
-}
-
 export const mapImageUrl = (url: string | undefined, block: Block) => {
   if (url === defaultPageCover || url === defaultPageIcon) {
-    return url
-  }
-
-  if (url && isNotionFileHostUrl(url)) {
     return url
   }
 

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -16,6 +16,7 @@ import {
 import { getTweetsMap } from './get-tweets'
 import { notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
+import { filterSignedUrls } from './signed-file-urls'
 import { type ExtendedPreviewImagesRecordMap } from './types'
 
 // Every Notion read shares one caching primitive: pMemoize + ExpiryMap.
@@ -58,19 +59,14 @@ const getNavigationLinkPages = pMemoize(
 async function getPageUncached(pageId: string): Promise<ExtendedRecordMap> {
   let recordMap = await notion.getPage(pageId)
   /**
-   * @wustep: fix for expiring images by removing signed AWS urls
-   * from https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/279#issuecomment-1245467818
+   * Drop short-lived signed file URLs so react-notion-x falls back to the
+   * unsigned block source and Notion's image proxy (stable across the ~1h
+   * expiry). Covers both the older `*.amazonaws.com` host and the current
+   * `file.notion.com` signed host.
+   * @see https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/279#issuecomment-1245467818
    */
-  if (recordMap && recordMap.signed_urls) {
-    const signedUrls = recordMap.signed_urls
-    const newSignedUrls: Record<string, string> = {}
-    for (const url in signedUrls) {
-      if (signedUrls[url] && signedUrls[url].includes('.amazonaws.com')) {
-        continue
-      }
-      newSignedUrls[url] = signedUrls[url]!
-    }
-    recordMap.signed_urls = newSignedUrls
+  if (recordMap?.signed_urls) {
+    recordMap.signed_urls = filterSignedUrls(recordMap.signed_urls)
   }
 
   if (navigationStyle !== 'default') {

--- a/lib/page-slug.ts
+++ b/lib/page-slug.ts
@@ -1,0 +1,72 @@
+import { type Block, type ExtendedRecordMap } from 'notion-types'
+import {
+  getBlockTitle,
+  getBlockValue,
+  getPageProperty,
+  parsePageId
+} from 'notion-utils'
+
+/**
+ * URL slug for a collection page: the explicit `Slug` property when set,
+ * otherwise a title-derived kebab slug. Matches how writing cards and the
+ * RSS feed already build hrefs.
+ */
+export function getPageSlug(
+  block: Block,
+  recordMap: ExtendedRecordMap
+): string | undefined {
+  const explicit = getPageProperty<string>('Slug', block, recordMap)?.trim()
+  if (explicit) {
+    return explicit.replace(/^\/+/, '')
+  }
+
+  const title = getBlockTitle(block, recordMap)
+  if (!title) {
+    return undefined
+  }
+
+  return slugifyTitle(title)
+}
+
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')
+}
+
+/**
+ * Collect slug → page-id mappings from collection pages already present in a
+ * record map (e.g. the /writing gallery). Hidden-from-home public posts show
+ * up here even though the home-page crawl never sees them.
+ */
+export function collectPublicPageSlugs(
+  recordMap: ExtendedRecordMap
+): Record<string, string> {
+  const map: Record<string, string> = {}
+
+  for (const blockId of Object.keys(recordMap.block || {})) {
+    const block = getBlockValue(recordMap.block[blockId])
+    if (
+      !block ||
+      block.type !== 'page' ||
+      block.parent_table !== 'collection'
+    ) {
+      continue
+    }
+
+    if (getPageProperty<boolean>('Public', block, recordMap) === false) {
+      continue
+    }
+
+    const slug = getPageSlug(block, recordMap)
+    const pageId = parsePageId(blockId, { uuid: true })
+    if (!slug || !pageId) {
+      continue
+    }
+
+    map[slug] ??= pageId
+  }
+
+  return map
+}

--- a/lib/posts-collection.ts
+++ b/lib/posts-collection.ts
@@ -1,0 +1,54 @@
+import ExpiryMap from 'expiry-map'
+import { type CollectionInstance, type ExtendedRecordMap } from 'notion-types'
+import pMemoize from 'p-memoize'
+
+import * as config from './config'
+import { notion } from './notion-api'
+import { collectPublicPageSlugs } from './page-slug'
+
+const SLUG_MAP_TTL_MS = 25 * 60 * 1000
+
+export function getCollectionBlockIds(
+  collectionData: CollectionInstance
+): string[] {
+  const collectionResult = collectionData.result
+  return (
+    collectionResult?.blockIds ??
+    collectionResult?.collection_group_results?.blockIds ??
+    collectionResult?.reducerResults?.collection_group_results?.blockIds ??
+    []
+  )
+}
+
+/**
+ * Slug map from every `pageUrlOverrides` page's collections. Those views
+ * (e.g. /writing) include public posts that are hidden from the home crawl.
+ */
+async function loadOverrideCollectionSlugMap(): Promise<
+  Record<string, string>
+> {
+  const overridePageIds = [
+    ...new Set(Object.values(config.pageUrlOverrides || {}))
+  ]
+  const merged: Record<string, string> = {}
+
+  await Promise.all(
+    overridePageIds.map(async (pageId) => {
+      try {
+        const recordMap = (await notion.getPage(pageId)) as ExtendedRecordMap
+        Object.assign(merged, collectPublicPageSlugs(recordMap))
+      } catch (err) {
+        console.warn('failed to load override page for slug map', pageId, err)
+      }
+    })
+  )
+
+  return merged
+}
+
+export const getOverrideCollectionSlugMap = pMemoize(
+  loadOverrideCollectionSlugMap,
+  {
+    cache: new ExpiryMap<undefined, Record<string, string>>(SLUG_MAP_TTL_MS)
+  }
+)

--- a/lib/resolve-notion-page.ts
+++ b/lib/resolve-notion-page.ts
@@ -1,12 +1,12 @@
 import { type ExtendedRecordMap } from 'notion-types'
-import { parsePageId } from 'notion-utils'
 
 import type { PageProps } from './types'
 import * as acl from './acl'
 import { pageUrlAdditions, pageUrlOverrides, site } from './config'
-import { normalizePageIdPath } from './normalize-page-id-path'
 import { getPage } from './notion'
 import { canonicalPageMap } from './notion-index'
+import { getOverrideCollectionSlugMap } from './posts-collection'
+import { lookupSlug, resolvePageIdFromMaps } from './resolve-page-id'
 
 export async function resolveNotionPage(
   domain: string,
@@ -16,27 +16,17 @@ export async function resolveNotionPage(
   let recordMap: ExtendedRecordMap
 
   if (rawPageId && rawPageId !== 'index') {
-    const normalizedRawPageId = normalizePageIdPath(rawPageId)
-    pageId = parsePageId(normalizedRawPageId)!
+    pageId = resolvePageIdFromMaps(rawPageId, {
+      pageUrlOverrides,
+      pageUrlAdditions,
+      canonicalPageMap
+    })
 
+    // Public posts hidden from the home crawl (e.g. /writing cards) are
+    // missing from the committed index. Resolve them from override-page
+    // collections so those hrefs don't 404.
     if (!pageId) {
-      // check if the site configuration provides an override or a fallback for
-      // the page's URI
-      const override =
-        pageUrlOverrides[rawPageId] ||
-        pageUrlAdditions[rawPageId] ||
-        pageUrlOverrides[normalizedRawPageId] ||
-        pageUrlAdditions[normalizedRawPageId]
-
-      if (override) {
-        pageId = parsePageId(override)!
-      }
-    }
-
-    if (!pageId) {
-      const mappedPageId =
-        canonicalPageMap[rawPageId] || canonicalPageMap[normalizedRawPageId]
-      pageId = mappedPageId ? parsePageId(mappedPageId)! : undefined
+      pageId = lookupSlug(rawPageId, await getOverrideCollectionSlugMap())
     }
 
     if (pageId) {

--- a/lib/resolve-page-id.ts
+++ b/lib/resolve-page-id.ts
@@ -1,0 +1,49 @@
+import { parsePageId } from 'notion-utils'
+
+import { normalizePageIdPath } from './normalize-page-id-path'
+
+export type PageIdLookupMaps = {
+  pageUrlOverrides: Record<string, string>
+  pageUrlAdditions: Record<string, string>
+  canonicalPageMap: Record<string, string>
+}
+
+/**
+ * Resolve a request path to a Notion page id using only in-memory maps
+ * (config overrides + the committed page index). Does not hit Notion.
+ */
+export function resolvePageIdFromMaps(
+  rawPageId: string,
+  maps: PageIdLookupMaps
+): string | undefined {
+  const normalizedRawPageId = normalizePageIdPath(rawPageId)
+  const parsed = parsePageId(normalizedRawPageId)
+  if (parsed) {
+    return parsed
+  }
+
+  const override =
+    maps.pageUrlOverrides[rawPageId] ||
+    maps.pageUrlAdditions[rawPageId] ||
+    maps.pageUrlOverrides[normalizedRawPageId] ||
+    maps.pageUrlAdditions[normalizedRawPageId]
+
+  if (override) {
+    return parsePageId(override) ?? undefined
+  }
+
+  const mappedPageId =
+    maps.canonicalPageMap[rawPageId] ||
+    maps.canonicalPageMap[normalizedRawPageId]
+
+  return mappedPageId ? (parsePageId(mappedPageId) ?? undefined) : undefined
+}
+
+export function lookupSlug(
+  slug: string,
+  slugMap: Record<string, string>
+): string | undefined {
+  const normalized = normalizePageIdPath(slug)
+  const pageId = slugMap[slug] || slugMap[normalized]
+  return pageId ? (parsePageId(pageId) ?? undefined) : undefined
+}

--- a/lib/signed-file-urls.ts
+++ b/lib/signed-file-urls.ts
@@ -1,0 +1,40 @@
+const EXPIRING_FILE_HOSTS = new Set([
+  'file.notion.com',
+  'file.notion.so',
+  'img.notionusercontent.com'
+])
+
+/**
+ * Notion signed file URLs expire in ~1h. `file.notion.com` is the current
+ * signed host for uploads that used to appear as `*.amazonaws.com`.
+ */
+export function isExpiringSignedFileUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname.endsWith('.amazonaws.com') || EXPIRING_FILE_HOSTS.has(hostname)
+    )
+  } catch {
+    return (
+      url.includes('.amazonaws.com') ||
+      url.includes('file.notion.com') ||
+      url.includes('file.notion.so') ||
+      url.includes('img.notionusercontent.com')
+    )
+  }
+}
+
+export function filterSignedUrls(
+  signedUrls: Record<string, string>
+): Record<string, string> {
+  const next: Record<string, string> = {}
+
+  for (const [blockId, url] of Object.entries(signedUrls)) {
+    if (!url || isExpiringSignedFileUrl(url)) {
+      continue
+    }
+    next[blockId] = url
+  }
+
+  return next
+}

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -36,8 +36,6 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   try {
     const props = await resolveNotionPage(domain, normalizedPageId)
 
-    // Notion-hosted file.notion.com URLs expire in ~1h. Rebuild often enough
-    // that next/image can fetch a still-valid signed URL.
     return { props, revalidate: 1800 }
   } catch (err: unknown) {
     console.error('page error', domain, requestedPageId, err)

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -6,6 +6,7 @@ import { domain, isDev, pageUrlAdditions, pageUrlOverrides } from '@/lib/config'
 import { normalizePageIdPath } from '@/lib/normalize-page-id-path'
 import { canonicalPageMap } from '@/lib/notion-index'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
+import { resolvePageIdFromMaps } from '@/lib/resolve-page-id'
 import { type PageProps, type Params } from '@/lib/types'
 
 export const config: PageConfig = {
@@ -13,18 +14,11 @@ export const config: PageConfig = {
 }
 
 async function getNotionFallbackUrl(rawPageId: string): Promise<string | null> {
-  const normalizedRawPageId = normalizePageIdPath(rawPageId)
-  let notionPageId =
-    pageUrlOverrides[rawPageId] ||
-    pageUrlAdditions[rawPageId] ||
-    pageUrlOverrides[normalizedRawPageId] ||
-    pageUrlAdditions[normalizedRawPageId] ||
-    parsePageId(normalizedRawPageId, { uuid: false })
-
-  if (!notionPageId) {
-    notionPageId =
-      canonicalPageMap[rawPageId] || canonicalPageMap[normalizedRawPageId]
-  }
+  const notionPageId = resolvePageIdFromMaps(rawPageId, {
+    pageUrlOverrides,
+    pageUrlAdditions,
+    canonicalPageMap
+  })
 
   if (!notionPageId) return null
   const normalizedNotionPageId = parsePageId(notionPageId, { uuid: false })

--- a/pages/feed.tsx
+++ b/pages/feed.tsx
@@ -12,6 +12,8 @@ import RSS from 'rss'
 import * as config from '@/lib/config'
 import { getSocialImageUrl } from '@/lib/get-social-image-url'
 import { notion } from '@/lib/notion-api'
+import { getPageSlug } from '@/lib/page-slug'
+import { getCollectionBlockIds } from '@/lib/posts-collection'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   if (req.method !== 'GET') {
@@ -78,12 +80,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       return { props: {} }
     }
 
-    const collectionResult = collectionData.result
-    const collectionBlockIds =
-      collectionResult?.blockIds ??
-      collectionResult?.collection_group_results?.blockIds ??
-      collectionResult?.reducerResults?.collection_group_results?.blockIds ??
-      []
+    const collectionBlockIds = getCollectionBlockIds(collectionData)
 
     if (!collectionBlockIds.length) {
       const feedText = feed.xml({ indent: true })
@@ -126,13 +123,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
         getPageProperty<string>('Description', block, recordMap) ||
         config.description
 
-      // Build the URL using the page slug or ID
-      const slug =
-        getPageProperty<string>('Slug', block, recordMap) ||
-        title
-          .toLowerCase()
-          .replaceAll(/[^a-z0-9]+/g, '-')
-          .replaceAll(/^-|-$/g, '')
+      const slug = getPageSlug(block, recordMap) || pageId
       const url = `${config.host}/${slug}`
 
       const lastUpdatedTime = getPageProperty<number>(

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,6 +13,9 @@
     <loc>https://wustep.me/bomberman</loc>
   </url>
   <url>
+    <loc>https://wustep.me/books-podcasts</loc>
+  </url>
+  <url>
     <loc>https://wustep.me/chorus</loc>
   </url>
   <url>
@@ -64,6 +67,9 @@
     <loc>https://wustep.me/philosophy</loc>
   </url>
   <url>
+    <loc>https://wustep.me/rapid-prototyping-highlighty</loc>
+  </url>
+  <url>
     <loc>https://wustep.me/shadbook</loc>
   </url>
   <url>
@@ -95,5 +101,8 @@
   </url>
   <url>
     <loc>https://wustep.me/wustep-me</loc>
+  </url>
+  <url>
+    <loc>https://wustep.me/wustep-me-ghost</loc>
   </url>
 </urlset>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two production bugs on wustep.me.

## Bug 1: `/writing` → Rapid Prototyping: Highlighty 404'd

The writing card href (`/rapid-prototyping-highlighty`) was correct — it comes from the post's `Slug` property. The page is a real public Notion post, **not** an external link (`External` is unchecked, `External URL` is empty).

It 404'd because the committed page index is built from the home-page crawl, and the home gallery filters **Hide from home**. Highlighty is public + hidden from home, so it never entered `canonicalPageMap`. `resolveNotionPage` only looked at that map (plus `pageUrlOverrides`), so the slug was unknown.

`fix/static-paths-url-overrides` is already on main and was not the right cut (it only added override paths like `/articles` to `getStaticPaths`).

**Fix:** collect public collection slugs from override pages like `/writing` at index time, resolve those slugs at request time if the committed index misses them, and add the missing entries (`rapid-prototyping-highlighty`, `books-podcasts`, `wustep-me-ghost`) to `notion-index.json` / the sitemap.

### Before (production)

[Production 404 for /rapid-prototyping-highlighty](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-highlighty-404.png)

[Writing index card for Rapid Prototyping: Highlighty](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-writing-highlighty-card.png)

### After (local)

[Highlighty article now loads at /rapid-prototyping-highlighty](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-highlighty-article.png)

[Writing index still lists Highlighty; the card opens the article](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-writing-highlighty-card.png)

## Bug 2: `/oct-25` images still broken after PR #21

PR #21 passed `file.notion.com` through without the Notion image proxy. That host is the **signed** form of an upload (replacing `*.amazonaws.com`), and those signatures expire in ~1h.

Separately, two apartment photos are **HEIC**. Passing them through as `file.notion.com` `.heic` files skips `next/image` and most browsers cannot display them — that's the broken “notion image” icon in the After column.

Dropping signed URLs so `react-notion-x` uses the unsigned `attachment:` source and wraps it in `notion.so/image` is the right stable URL (and the proxy converts HEIC → JPEG). But `notion.so/image` now **302s** to `img.notionusercontent.com`, and `next/image` rejects that redirect as “upstream response is invalid”.

**Fix:**
1. Drop `file.notion.com` / S3 signed URLs from `recordMap.signed_urls` (the existing S3 expiry strategy, updated for the new host).
2. Keep wrapping unsigned sources in `notion.so/image`.
3. Render Notion-proxied (and HEIC) images `unoptimized` so the browser follows the 302.

### Before (production)

The After-column HEIC is the broken “notion image” icon; other photos still load while signatures are fresh.

[Production /oct-25 with a broken HEIC apartment photo](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-oct-25-images.png)

### After (local)

[Local /oct-25 Before/After apartment photos including the previously broken HEICs](https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-oct-25-images.png)

## Test plan

- [x] `pnpm test:unit` — 71 tests
- [x] `pnpm typecheck`
- [x] Local `/writing` → Highlighty card opens the article (not 404)
- [x] Local `/rapid-prototyping-highlighty` renders the May 2019 article
- [x] Local `/oct-25` images load, including the After-column HEIC photos


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38300879-1cc8-4108-acff-150a57c79244?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38300879-1cc8-4108-acff-150a57c79244&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

