### PR TITLE
fix: stop nested pages from 404ing the favicon

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,7 +6,21 @@ export default class MyDocument extends Document {
       <Html lang='en'>
         <Head>
           <link rel='shortcut icon' href='/favicon.ico' />
-          <link rel='icon' type='image/png' sizes='32x32' href='favicon.png' />
+          {/* Root-absolute hrefs: a relative favicon.png resolves to
+              /{slug}/favicon.png on nested routes and 404s. */}
+          <link
+            rel='icon'
+            type='image/png'
+            sizes='32x32'
+            href='/favicon-32x32.png'
+          />
+          <link
+            rel='icon'
+            type='image/png'
+            sizes='192x192'
+            href='/favicon-192x192.png'
+          />
+          <link rel='apple-touch-icon' href='/favicon-192x192.png' />
         </Head>
 
         <body>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The document head used a relative `favicon.png` href. On nested routes that resolves to `/{slug}/favicon.png`, which 404s. Confirmed live: `https://wustep.me/philosophy/favicon.png` is a 404, while `https://wustep.me/favicon.png` is fine.

This hits philosophy, journal, and every other non-root page — tab icon, iOS home-screen icon, and crawlers all request the broken URL.

## What changed

In `pages/_document.tsx`:

- Point the 32×32 PNG icon at `/favicon-32x32.png` (root-absolute)
- Add `/favicon-192x192.png` for high-DPI tabs
- Add `apple-touch-icon` for iOS home-screen / mobile chrome
- Leave `/favicon.ico` as the shortcut icon

No visual redesign. Existing files in `public/` already had the correctly sized assets.

## Why

Sitewide chrome/SEO: every nested page was asking the browser for a favicon that does not exist at that path. Homepage happened to work because `/favicon.png` is a valid relative resolution from `/`.

## Before / after

**Before (production):** the URL the relative `href="favicon.png"` actually requests on `/philosophy`:

[Production 404 at /philosophy/favicon.png](https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffavicon-before-philosophy-404.png)

**After:** root-absolute icons the document head now serves:

[Root-absolute 32 and 192 turtle favicons](https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffavicon-after-root-absolute.png)

Philosophy page itself is unchanged (this is head-only):

[Production /philosophy page](https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprod-philosophy-desktop.png)

## Test plan

- [ ] View source on `/`, `/philosophy`, and a journal slug: every `rel="icon"` / `apple-touch-icon` href starts with `/`
- [ ] `curl -sI https://<preview>/philosophy/favicon.png` can still 404 (unused); `curl -sI https://<preview>/favicon-32x32.png` and `/favicon-192x192.png` are 200
- [ ] Open `/philosophy` and `/headspace` in a fresh tab: turtle favicon shows (not a generic/broken icon)
- [ ] Homepage favicon still shows
- [ ] On a phone, “Add to Home Screen” uses the 192px turtle


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eed888b-b209-4fba-95c2-8c08b4fd894f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

