### PR TITLE
perf: drop unused Google Fonts from Notion page head

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -96,17 +96,6 @@ export function PageHead({
         title={site?.name}
       />
 
-      <link rel='preconnect' href='https://fonts.googleapis.com' />
-      <link
-        rel='preconnect'
-        href='https://fonts.gstatic.com'
-        crossOrigin='anonymous'
-      />
-      <link
-        href='https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Spectral:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;1,200;1,300;1,400;1,500;1,600;1,700;1,800&display=swap'
-        rel='stylesheet'
-      />
-
       <meta property='og:title' content={title} />
       <meta name='twitter:title' content={title} />
       <title>{title}</title>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Every Notion-backed page (philosophy, journal, essays) still loads a render-blocking Google Fonts stylesheet from `PageHead`:

- Crimson Pro (already self-hosted via `next/font` in `_app.tsx`)
- Source Sans 3 and Spectral (only used on `/design/fonts`)

Confirmed live on `https://wustep.me/philosophy` — the HTML includes `fonts.googleapis.com` / `fonts.gstatic.com` preconnects plus the full variable-font CSS.

Homepage is unaffected (it does not render `PageHead`). Design-lab faces stay on `lib/fonts/design-fonts.ts`.

## What changed

Removed the three Google Fonts `<link>` tags from `components/PageHead.tsx`. Site type on journal/philosophy continues to come from Inter + Crimson Pro via `next/font`.

## Why

Shell performance for the pages that are not the homepage but still matter (philosophy, journal). One fewer render-blocking stylesheet and two fewer third-party origins on every article. No type redesign.

## Before / after

The article chrome looks the same — production `/philosophy` already uses the next/font families; Google Fonts was extra:

[Production /philosophy page](https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprod-philosophy-desktop.png)

What actually changes is the document head:

[Before and after PageHead font links](https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffonts-before-after.png)

## Test plan

- [ ] View source on `/philosophy` and a journal post: no `fonts.googleapis.com` or `fonts.gstatic.com`
- [ ] Homepage `/` still has no Google Fonts links (already true)
- [ ] `/design/fonts` still loads Source Sans 3 / Spectral via `designFontsStylesheetUrl`
- [ ] Visual: `/philosophy` headings still Crimson Pro, UI still Inter, light and dark
- [ ] Network panel on a cold load of `/philosophy`: no request to `fonts.googleapis.com`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eed888b-b209-4fba-95c2-8c08b4fd894f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eed888b-b209-4fba-95c2-8c08b4fd894f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

