### PR TITLE
fix(playground): Bookshelf first-load is no longer a blank page

### DIFF
--- a/pages/playground/bookshelf.tsx
+++ b/pages/playground/bookshelf.tsx
@@ -3,8 +3,46 @@ import { useEffect, useState } from 'react'
 import { PlaygroundLayout } from '@/components/wustep/PlaygroundLayout'
 import { useDarkMode } from '@/lib/use-dark-mode'
 
+const SPINE_COLORS = [
+  '#e74c3c',
+  '#3b82f6',
+  '#22c55e',
+  '#f59e0b',
+  '#a855f7',
+  '#06b6d4',
+  '#ec4899'
+]
+
+const SPINE_HEIGHTS = ['70%', '85%', '60%', '90%', '75%', '65%', '80%']
+
+function BookshelfLoading() {
+  return (
+    <div
+      className='absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-background'
+      role='status'
+      aria-live='polite'
+    >
+      <div className='flex h-16 items-end gap-1.5' aria-hidden='true'>
+        {SPINE_COLORS.map((color, i) => (
+          <span
+            key={color}
+            className='w-3 animate-pulse rounded-t-sm'
+            style={{
+              background: color,
+              height: SPINE_HEIGHTS[i],
+              animationDelay: `${i * 80}ms`
+            }}
+          />
+        ))}
+      </div>
+      <p className='text-sm text-muted-foreground'>Loading the bookshelf…</p>
+    </div>
+  )
+}
+
 export default function PlaygroundBookshelfPage() {
   const [hasMounted, setHasMounted] = useState(false)
+  const [loaded, setLoaded] = useState(false)
   const { isDarkMode } = useDarkMode()
   const mode = isDarkMode ? 'dark' : 'light'
 
@@ -12,22 +50,33 @@ export default function PlaygroundBookshelfPage() {
     setHasMounted(true)
   }, [])
 
+  // Cross-origin onLoad usually fires; if the embed hangs, drop the
+  // overlay so a failed frame is still visible instead of a forever wait.
+  useEffect(() => {
+    if (!hasMounted) return
+    const timeout = window.setTimeout(() => setLoaded(true), 8000)
+    return () => window.clearTimeout(timeout)
+  }, [hasMounted])
+
   return (
     <PlaygroundLayout
       title='Bookshelf'
       breadcrumbs={[{ label: 'Bookshelf' }]}
       fullFrame
     >
-      {hasMounted && (
-        <iframe
-          src={`https://wustep-bookshelf.vercel.app/?mode=${mode}`}
-          title='Bookshelf iframe'
-          className='flex-1 w-full border-0'
-          loading='lazy'
-          allow='fullscreen *'
-          allowFullScreen
-        />
-      )}
+      <div className='relative min-h-0 flex-1'>
+        {(!hasMounted || !loaded) && <BookshelfLoading />}
+        {hasMounted && (
+          <iframe
+            src={`https://wustep-bookshelf.vercel.app/?mode=${mode}`}
+            title='Bookshelf'
+            className='absolute inset-0 h-full w-full border-0'
+            allow='fullscreen *'
+            allowFullScreen
+            onLoad={() => setLoaded(true)}
+          />
+        )}
+      </div>
     </PlaygroundLayout>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/playground/bookshelf` waited for client hydration, then inserted a `loading="lazy"` iframe, with nothing on screen in between. On a cold visit that is a couple of seconds of empty white — it reads as broken.

## What changed

- Paint a small spine placeholder (same colors as the Bookshelf cover) and “Loading the bookshelf…” as soon as the playground chrome is up.
- Keep that overlay until the iframe `onLoad`s (or 8s, so a hung embed is still visible).
- Drop `loading="lazy"` — this iframe *is* the page.
- Still wait for mount before setting `?mode=` so the embed matches light/dark.

## Why

Bookshelf is one of the playground toys people actually open. A blank frame is the first thing they feel.

## Screenshots

**Before** (production): empty white frame until the embed arrives.

[Bookshelf before — blank first load](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbookshelf-before-blank.png)

**After** (this branch): spines + loading copy immediately, then the real shelf.

[Bookshelf after — loading skeleton](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbookshelf-after-loading.png)
[Bookshelf after — loaded grid](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbookshelf-after-loaded.png)

## Test plan

1. Open `/playground/bookshelf` with cache disabled — spines + loading copy appear immediately, then the real shelf replaces them.
2. Toggle light/dark and reload — the embed still matches the playground theme.
3. Confirm the loaded bookshelf still fills the frame and filters work.
4. Other playground pages unchanged.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e654740f-92b9-4bc9-8f85-65d43e494399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

