### PR TITLE
fix(playground): open iframe games in their own tab

### DIFF
--- a/components/wustep/PlaygroundLayout.tsx
+++ b/components/wustep/PlaygroundLayout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import * as React from 'react'
 
@@ -66,13 +67,16 @@ interface PlaygroundLayoutProps {
   breadcrumbs?: { label: string; href?: string }[]
   /** When true, children fill the entire frame (no padding, no title, no max-width) */
   fullFrame?: boolean
+  /** Standalone URL for iframe toys — shown as an "open in its own tab" header action. */
+  openHref?: string
 }
 
 export function PlaygroundLayout({
   children,
   title,
   breadcrumbs = [],
-  fullFrame = false
+  fullFrame = false,
+  openHref
 }: PlaygroundLayoutProps) {
   const [hasMounted, setHasMounted] = React.useState(false)
   const [isSidebarOpen, setIsSidebarOpen] = React.useState(true)
@@ -115,6 +119,7 @@ export function PlaygroundLayout({
           isDarkMode={isDarkMode}
           toggleDarkMode={toggleDarkMode}
           fullFrame={fullFrame}
+          openHref={openHref}
         >
           {children}
         </LayoutContent>
@@ -136,7 +141,8 @@ function LayoutContent({
   hasMounted,
   isDarkMode,
   toggleDarkMode,
-  fullFrame
+  fullFrame,
+  openHref
 }: LayoutContentProps) {
   const { state, isMobile } = useSidebar()
   const insetStyle = React.useMemo(() => {
@@ -202,6 +208,18 @@ function LayoutContent({
             onToggle={toggleDarkMode}
             className='playground-theme-button playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
           />
+          {openHref ? (
+            <a
+              href={openHref}
+              target='_blank'
+              rel='noreferrer'
+              aria-label='Open in its own tab'
+              title='Open in its own tab'
+              className='playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
+            >
+              <ExternalLink className='h-4 w-4' aria-hidden='true' />
+            </a>
+          ) : null}
         </div>
       </header>
       {fullFrame ? (

--- a/pages/playground/bomberman.tsx
+++ b/pages/playground/bomberman.tsx
@@ -6,6 +6,7 @@ export default function PlaygroundBombermanPage() {
       title='Bomberman'
       breadcrumbs={[{ label: 'Bomberman' }]}
       fullFrame
+      openHref='https://wustep-bomberman.vercel.app/'
     >
       <iframe
         src='https://wustep-bomberman.vercel.app/'

--- a/pages/playground/splashpanic.tsx
+++ b/pages/playground/splashpanic.tsx
@@ -6,6 +6,7 @@ export default function PlaygroundSplashPanicPage() {
       title='Splash Panic!'
       breadcrumbs={[{ label: 'Splash Panic!' }]}
       fullFrame
+      openHref='https://splashpanic.vercel.app/'
     >
       <iframe
         src='https://splashpanic.vercel.app/'

--- a/pages/playground/spot-it.tsx
+++ b/pages/playground/spot-it.tsx
@@ -6,6 +6,7 @@ export default function PlaygroundSpotItPage() {
       title='Spot it!'
       breadcrumbs={[{ label: 'Spot it!' }]}
       fullFrame
+      openHref='https://spot-its.vercel.app/'
     >
       <iframe
         src='https://spot-its.vercel.app/'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bomberman, Splash Panic, and Spot it! run in an iframe. Arrow keys and space still scroll the playground page in some browsers, so a game session fights the host chrome.

## What changed

- `PlaygroundLayout` accepts an optional `openHref`.
- When set, the header grows an **Open in its own tab** action (same hit-area treatment as Home / theme).
- Wired on the three game embeds: Splash Panic, Bomberman, Spot it!.

## Why

The playground-entry skill already calls this out for games. These three had no escape hatch. One click gets a real tab where keys belong to the game.

## Screenshots

**Before** (production Bomberman): header is Home + theme only.

[Bomberman before — no open-in-tab control](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbomberman-before-desktop.png)

**After** (this branch): external-link action after the theme toggle.

[Bomberman after — open in its own tab](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbomberman-after-desktop.png)
[Splash Panic after — same header action](https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsplashpanic-after-desktop.png)

Non-game toys (Bookshelf, MIDI Visualizer, Starry Sequencer) do not get the icon.

## Test plan

1. Open `/playground/bomberman`, `/playground/splashpanic`, and `/playground/spot-it`.
2. Confirm the new header icon sits after the theme toggle, has a tooltip, and opens the standalone app in a new tab.
3. Confirm `/playground` and non-game toys do **not** show the icon.
4. Keyboard: Tab to the new control, Enter opens the standalone URL.

## Out of scope

No game rewrites, no loading-state work (that's a separate concern), no analytics or sitewide nav.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e654740f-92b9-4bc9-8f85-65d43e494399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

