### PR TITLE
fix(feed): stop advertising leftover Highlighty Part 2 404

### DIFF
--- a/lib/__tests__/resolve-page-id.test.ts
+++ b/lib/__tests__/resolve-page-id.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { lookupSlug, resolvePageIdFromMaps } from '../resolve-page-id'
+import {
+  isResolvablePageSlug,
+  lookupSlug,
+  resolvePageIdFromMaps
+} from '../resolve-page-id'
 
 const maps = {
   pageUrlOverrides: {
@@ -48,5 +52,25 @@ describe('lookupSlug', () => {
         'rapid-prototyping-highlighty': '2bc5cb08-cf2c-810b-83af-c01fde10aefa'
       })
     ).toBe('2bc5cb08-cf2c-810b-83af-c01fde10aefa')
+  })
+})
+
+describe('isResolvablePageSlug', () => {
+  it('accepts slugs in the committed index', () => {
+    expect(isResolvablePageSlug('oct-25', maps)).toBe(true)
+  })
+
+  it('accepts slugs from override-page collections', () => {
+    expect(
+      isResolvablePageSlug('rapid-prototyping-highlighty', maps, {
+        'rapid-prototyping-highlighty': '2bc5cb08-cf2c-810b-83af-c01fde10aefa'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects leftover posts that are not on any public listing', () => {
+    expect(
+      isResolvablePageSlug('rapid-prototyping-highlighty-part-2', maps)
+    ).toBe(false)
   })
 })

--- a/lib/resolve-page-id.ts
+++ b/lib/resolve-page-id.ts
@@ -47,3 +47,18 @@ export function lookupSlug(
   const pageId = slugMap[slug] || slugMap[normalized]
   return pageId ? (parsePageId(pageId) ?? undefined) : undefined
 }
+
+/**
+ * True when `/<slug>` would resolve the same way `resolveNotionPage` does:
+ * committed index / URL overrides, then collection slugs from override pages.
+ * Used to keep the RSS feed from advertising leftover posts that 404.
+ */
+export function isResolvablePageSlug(
+  slug: string,
+  maps: PageIdLookupMaps,
+  extraSlugMap: Record<string, string> = {}
+): boolean {
+  return Boolean(
+    resolvePageIdFromMaps(slug, maps) || lookupSlug(slug, extraSlugMap)
+  )
+}

--- a/pages/feed.tsx
+++ b/pages/feed.tsx
@@ -12,8 +12,13 @@ import RSS from 'rss'
 import * as config from '@/lib/config'
 import { getSocialImageUrl } from '@/lib/get-social-image-url'
 import { notion } from '@/lib/notion-api'
+import { canonicalPageMap } from '@/lib/notion-index'
 import { getPageSlug } from '@/lib/page-slug'
-import { getCollectionBlockIds } from '@/lib/posts-collection'
+import {
+  getCollectionBlockIds,
+  getOverrideCollectionSlugMap
+} from '@/lib/posts-collection'
+import { isResolvablePageSlug } from '@/lib/resolve-page-id'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   if (req.method !== 'GET') {
@@ -94,6 +99,13 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       return { props: {} }
     }
 
+    const extraSlugMap = await getOverrideCollectionSlugMap()
+    const pageIdMaps = {
+      pageUrlOverrides: config.pageUrlOverrides,
+      pageUrlAdditions: config.pageUrlAdditions,
+      canonicalPageMap
+    }
+
     // Get all pages that belong to this collection
     for (const blockId of collectionBlockIds) {
       const block =
@@ -124,6 +136,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
         config.description
 
       const slug = getPageSlug(block, recordMap) || pageId
+      if (!isResolvablePageSlug(slug, pageIdMaps, extraSlugMap)) {
+        console.warn('skipping feed item with unresolvable slug', slug)
+        continue
+      }
       const url = `${config.host}/${slug}`
 
       const lastUpdatedTime = getPageProperty<number>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What was wrong

`/feed` still lists **Rapid Prototyping: Highlighty (Part 2)** at `/rapid-prototyping-highlighty-part-2`. That post is marked Public in the Notion posts collection (so RSS picks it up), but it is hidden from home and `/writing`, so it is not in the committed page index. Visiting the URL is a soft 404:

[Production 404 for /rapid-prototyping-highlighty-part-2](https://cursor.com/agents/bc-061ebc97-5f98-4b1e-a24a-802865917d97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffeed-part2-404-before.png)

This is leftover from the Highlighty article pair. Part 1 (`/rapid-prototyping-highlighty`) is real and already fixed in #24. Part 2 is an unpublished leftover that subscribers still get as a dead link.

#### Why it matters

RSS is a public listing. Advertising a URL that 404s is worse than omitting a hidden draft. The feed description for Part 2 also falls back to the generic site tagline (`Software Engineer, San Francisco, CA`), which is another leftover-article smell.

#### What changed

Feed items are now skipped unless `/<slug>` would resolve the same way page routes do: committed index / URL overrides, then collection slugs from override pages like `/writing`. Hidden leftover posts stay out of the feed. Real hidden-from-home posts that *are* on `/writing` (Part 1) still resolve and still appear.

#### Test plan

- [x] Unit tests for `isResolvablePageSlug` (index hit, writing-collection hit, leftover Part 2 miss)
- [ ] `GET /feed` no longer contains `rapid-prototyping-highlighty-part-2`
- [ ] `/feed` still includes `/rapid-prototyping-highlighty`, `/oct-25`, `/philosophy`
- [ ] `/rapid-prototyping-highlighty-part-2` still 404s (intentional; this PR does not publish the leftover page)

#### Notion Test Page ID

`2bc5cb08cf2c81639fb3f549654b6a7c` (Highlighty Part 2 — leftover, 404s on the site)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-061ebc97-5f98-4b1e-a24a-802865917d97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061ebc97-5f98-4b1e-a24a-802865917d97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

