### PR TITLE
fix(prompting): update stale Cursor and Claude docs links

### DIFF
--- a/components/wustep/prompting/TechniquesContent.tsx
+++ b/components/wustep/prompting/TechniquesContent.tsx
@@ -101,7 +101,7 @@ export function TechniquesContent() {
         </p>
         <div className={styles.skillsLinks}>
           <a
-            href='https://docs.claude.com/en/docs/claude-code/skills'
+            href='https://code.claude.com/docs/en/skills'
             className={styles.skillsLink}
             target='_blank'
             rel='noopener noreferrer'
@@ -112,7 +112,7 @@ export function TechniquesContent() {
             </span>
           </a>
           <a
-            href='https://docs.cursor.com/en/context/rules'
+            href='https://cursor.com/docs/rules'
             className={styles.skillsLink}
             target='_blank'
             rel='noopener noreferrer'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What was wrong

The Prompting techniques chapter (“Lift them into skills”) linked Cursor Rules to `https://docs.cursor.com/en/context/rules`. That path no longer serves the Rules page — it redirects to the generic Cursor docs index (`https://cursor.com/docs`). Readers who follow the link never land on Rules.

Claude Skills used the old `docs.claude.com/en/docs/claude-code/skills` URL, which now redirects to `https://code.claude.com/docs/en/skills`.

**Before (production)**

[Production prompting techniques skills links](https://cursor.com/agents/bc-061ebc97-5f98-4b1e-a24a-802865917d97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprompting-docs-links-before.png)

**After (this branch)**

[Updated prompting techniques skills links](https://cursor.com/agents/bc-061ebc97-5f98-4b1e-a24a-802865917d97/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fprompting-docs-links-after.png)

Visible chrome is unchanged; only the destinations move.

#### Why it matters

`/prompting` is linked from the homepage writing list. A stale docs link in the “write the lesson once” closer sends people to the wrong page at the exact moment the article tells them to look up the real mechanism.

#### What changed

- Cursor · Rules → `https://cursor.com/docs/rules`
- Claude Code · Skills → `https://code.claude.com/docs/en/skills`

#### Test plan

- [x] `https://cursor.com/docs/rules` returns the Rules doc (not the docs homepage)
- [x] `https://code.claude.com/docs/en/skills` returns the Skills doc
- [x] Local `/prompting/techniques` HTML contains the new hrefs and not the old ones
- [ ] Open `/prompting/techniques`, scroll to “Lift them into skills”
- [ ] Cursor · Rules opens the Rules page
- [ ] Claude Code · Skills opens the Skills page
- [ ] Codex · AGENTS.md unchanged

#### Notion Test Page ID

n/a — this is a static `/prompting` page, not a Notion article.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-061ebc97-5f98-4b1e-a24a-802865917d97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061ebc97-5f98-4b1e-a24a-802865917d97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

