### PR TITLE
fix(playground): drop Starry Sequencer header open-in-tab

### DIFF
--- a/pages/playground/starry-sequencer.tsx
+++ b/pages/playground/starry-sequencer.tsx
@@ -14,7 +14,6 @@ export default function PlaygroundStarryNightPage() {
       title='Starry Night Sequencer'
       breadcrumbs={[{ label: 'Starry Night Sequencer' }]}
       fullFrame
-      openHref={PLAYER_URL}
     >
       <div className='flex min-h-0 min-w-0 flex-1 flex-col'>
         <p className='text-muted-foreground shrink-0 border-b px-4 py-3 text-sm'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#28 landed with `openHref={PLAYER_URL}` still on Starry Sequencer, so the playground header shows an ExternalLink icon. Stephen does not want that control on this page.

## What changed

One line: remove `openHref={PLAYER_URL}` from `pages/playground/starry-sequencer.tsx`.

## Why

The header icon is leftover from the merge. Games keep their `openHref` via `PlaygroundLayout`. Starry keeps fullFrame, poster, iframe fade-in, and the copy fix.

## Test plan

1. Open `/playground/starry-sequencer` — header is Home + theme only.
2. Confirm the blurb, poster/iframe, and fill-the-frame layout are unchanged.
3. Confirm `/playground/bomberman`, `/playground/splashpanic`, and `/playground/spot-it` still show the header open-in-tab icon.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e654740f-92b9-4bc9-8f85-65d43e494399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e654740f-92b9-4bc9-8f85-65d43e494399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

