### PR TITLE
fix(playground): keep open-in-tab chrome aligned

### DIFF
--- a/components/wustep/PlaygroundLayout.tsx
+++ b/components/wustep/PlaygroundLayout.tsx
@@ -195,6 +195,24 @@ function LayoutContent({
           </BreadcrumbList>
         </Breadcrumb>
         <div className='relative ml-auto flex items-center gap-2'>
+          {openHref ? (
+            <a
+              href={openHref}
+              target='_blank'
+              rel='noreferrer'
+              aria-label='Open in its own tab'
+              title='Open in its own tab'
+              className='playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
+            >
+              <ExternalLink className='h-4 w-4' aria-hidden='true' />
+            </a>
+          ) : (
+            <span aria-hidden='true' className='inline-flex h-8 w-8' />
+          )}
+          <Separator
+            orientation='vertical'
+            className='data-[orientation=vertical]:h-4'
+          />
           <Link
             href='/'
             className='playground-home-button playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors after:absolute after:-inset-1.5'
@@ -208,18 +226,6 @@ function LayoutContent({
             onToggle={toggleDarkMode}
             className='playground-theme-button playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
           />
-          {openHref ? (
-            <a
-              href={openHref}
-              target='_blank'
-              rel='noreferrer'
-              aria-label='Open in its own tab'
-              title='Open in its own tab'
-              className='playground-action-button relative inline-flex h-8 w-8 items-center justify-center rounded-md after:absolute after:-inset-1.5'
-            >
-              <ExternalLink className='h-4 w-4' aria-hidden='true' />
-            </a>
-          ) : null}
         </div>
       </header>
       {fullFrame ? (

--- a/pages/playground/starry-sequencer.tsx
+++ b/pages/playground/starry-sequencer.tsx
@@ -14,6 +14,7 @@ export default function PlaygroundStarryNightPage() {
       title='Starry Night Sequencer'
       breadcrumbs={[{ label: 'Starry Night Sequencer' }]}
       fullFrame
+      openHref={PLAYER_URL}
     >
       <div className='flex min-h-0 min-w-0 flex-1 flex-col'>
         <p className='text-muted-foreground shrink-0 border-b px-4 py-3 text-sm'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore the Starry Sequencer header “open in its own tab” action and stop Home/theme from jumping when a playground page has no `openHref`.

#### Description

Stephen wants the playground “open in its own tab” header icon kept — including on Starry Sequencer — but the chrome must stay stable.

**Starry Sequencer.** `#34` removed `openHref` from this page. It is restored as `openHref={PLAYER_URL}`. Iframe / `fullFrame` / poster behavior is unchanged. No banner “Open in tab” text link.

**Header actions.** Right-side order is now:

`[open-in-tab] | [Home] [theme]`

- Open-in-tab sits left of Home, with a vertical divider between them.
- When `openHref` is missing, the same 8×8 slot is reserved (`aria-hidden`, not a link) and the divider still renders, so Home + theme stay a fixed cluster.
- Existing `playground-action-button` / ExternalLink `h-4 w-4` styling is unchanged. The link keeps `aria-label` / `title` “Open in its own tab”.

Measured at 1440px: Home is at x=1356 and theme at x=1396 on Bomberman (`openHref`), StageBench (no `openHref`), and Starry (restored). The reserved span is 32×32 in the same slot as the link.

#### Before (main)

Home/theme sit with the other header actions. The ExternalLink is on the far right when present, so Home/theme jump.

[Before: Bomberman, StageBench, and Starry headers — Home/theme shift when open-in-tab is missing](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcomparison-all-three.png)

Bomberman (`openHref` — icon on the right of theme):

[Before: Bomberman header with open-in-tab after Home and theme](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbomberman-header-cropped.png)

StageBench (no `openHref` — Home/theme shifted right):

[Before: StageBench header without open-in-tab](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstagebench-header-cropped.png)

Starry (open-in-tab removed):

[Before: Starry Sequencer header without open-in-tab](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstarry-sequencer-header-cropped.png)

#### After

`[open-in-tab] | [Home] [theme]`. Divider always shown. Home/theme stay put.

Bomberman:

[After: Bomberman header with open-in-tab left of a divider, then Home and theme](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbomberman-header-after-full.png)

StageBench (reserved empty slot, same Home/theme position):

[After: StageBench header with reserved open-in-tab slot and aligned Home/theme](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstagebench-header-after-full.png)

Starry (open-in-tab restored):

[After: Starry Sequencer header with open-in-tab restored left of Home/theme](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstarry-header-after-full.png)

Right-edge crops (same crop from the viewport edge):

Bomberman · StageBench · Starry

[After right cluster: Bomberman](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbomberman-header-after-full-right.png)
[After right cluster: StageBench reserved slot](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstagebench-header-after-full-right.png)
[After right cluster: Starry](https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstarry-header-after-full-right.png)

#### Notion Test Page ID

N/A — playground chrome only; no Notion page change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91e6e9b6-2338-48d4-8cd6-c339eabb9fbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

