### PR TITLE
Make wustep.me readable to agents (is-agentic 404s, markdown, llms.txt)

### DIFF
--- a/components/AboutPage.module.css
+++ b/components/AboutPage.module.css
@@ -92,6 +92,8 @@
   /* Semantic <h1>; the wordmark link owns all visual sizing, so strip the
      browser's default heading margin and font. */
   margin: 0;
+  font-size: inherit;
+  font-family: inherit;
   font-weight: inherit;
 }
 
@@ -1134,6 +1136,24 @@ a.bioHint {
   outline: 2px solid var(--about-accent);
   outline-offset: 4px;
   border-radius: 4px;
+  color: var(--about-accent);
+}
+
+.footerMeta {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 16px;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+}
+
+.footerMeta a {
+  color: var(--about-muted);
+}
+
+.footerMeta a:hover,
+.footerMeta a:focus-visible {
   color: var(--about-accent);
 }
 

--- a/components/AboutPage.tsx
+++ b/components/AboutPage.tsx
@@ -1,9 +1,12 @@
-'use client'
-
 import Link from 'next/link'
 import * as React from 'react'
 
 import { github, linkedin, x } from '@/lib/config'
+import {
+  workHistory,
+  writingPersonal,
+  writingSoftware
+} from '@/lib/site-identity'
 
 import styles from './AboutPage.module.css'
 import { DesignButton } from './wustep/DesignButton'
@@ -12,78 +15,7 @@ import { Illustration } from './wustep/lenses/illustrations'
 import { OwnerModeToggle } from './wustep/OwnerModeToggle'
 import { ThemeToggle } from './wustep/ThemeToggle'
 
-// Plain-text mirror of the hero bio JSX below — used for meta descriptions.
-export const bioText = `I'm Stephen, a product & design engineer who now also manages engineers. I think a lot about tools for thought, software design, and personal philosophy. I grew up mostly in Toledo, Ohio, and live in San Francisco now. I also enjoy roguelike deckbuilders, piano improvisation, and making random web projects.`
-
-const workHistory = [
-  {
-    company: 'Notion',
-    icon: 'notion',
-    url: 'https://notion.com',
-    roles: [
-      { title: 'Tech Lead Manager', period: '2025–' },
-      { title: 'Software Engineer', period: '2022–2025' }
-    ]
-  },
-  {
-    company: 'Facebook',
-    icon: 'facebook',
-    roles: [{ title: 'Software Engineer', period: '2019–2022' }]
-  },
-  {
-    company: 'Ohio State',
-    icon: 'osu',
-    roles: [
-      { title: 'B.S. Computer Science & Engineering', period: '2015–2019' }
-    ]
-  }
-]
-
-const writingSoftware = [
-  {
-    title: 'Prompting',
-    href: '/prompting',
-    note: 'talking to coding agents'
-  },
-  {
-    title: 'Advice for students',
-    href: '/advice-students',
-    note: 'career pathfinding'
-  },
-  {
-    title: 'Graphs of knowledge',
-    href: '/cs-knowledge-graph',
-    note: 'careers as infinite trees'
-  },
-  {
-    title: "Don't thrash the user",
-    href: '/thrash',
-    note: 'empathetic ui/ux'
-  }
-]
-
-const writingPersonal = [
-  {
-    title: 'Headspace',
-    href: '/headspace',
-    note: 'identity, growth, thought-space'
-  },
-  {
-    title: 'Foraging',
-    href: '/foraging',
-    note: 'ADHD, dopamine, attention'
-  },
-  {
-    title: 'On philosophy',
-    href: '/philosophy',
-    note: 'moral philosophy, lenses'
-  },
-  {
-    title: "oct '25",
-    href: '/oct-25',
-    note: 'life update'
-  }
-]
+export { bioText } from '@/lib/site-identity'
 
 function Tooltip({
   children,
@@ -265,11 +197,9 @@ export function AboutPage() {
       <div className={styles.container}>
         <header className={`${styles.header} owner-mode-toggle-reveal-group`}>
           <div className={styles.headerLeft}>
-            <h1 className={styles.nameRow}>
-              <Link href='/' className={styles.wordmark}>
-                Stephen Wu
-              </Link>
-            </h1>
+            <Link href='/' className={styles.wordmark}>
+              <h1 className={styles.nameRow}>Stephen Wu</h1>
+            </Link>
             <span className={styles.title}>Engineering at Notion</span>
           </div>
 
@@ -696,6 +626,10 @@ export function AboutPage() {
               Get in touch →
             </a>
           </Tooltip>
+          <nav className={styles.footerMeta} aria-label='Site'>
+            <a href='/privacy'>Privacy</a>
+            <a href='/llms.txt'>llms.txt</a>
+          </nav>
         </footer>
       </div>
     </main>

--- a/components/Page404.module.css
+++ b/components/Page404.module.css
@@ -75,9 +75,26 @@
   color: var(--w-secondary);
   font-size: 0.95rem;
   line-height: 1.6;
-  margin: 0 0 2rem;
+  margin: 0 0 0.75rem;
   max-width: 320px;
   animation: fadeIn 800ms var(--ease-out-quart) 400ms both;
+}
+
+.hints {
+  color: var(--w-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin: 0 0 2rem;
+  animation: fadeIn 800ms var(--ease-out-quart) 450ms both;
+}
+
+.hints a {
+  color: var(--w-secondary);
+}
+
+.hints a:hover,
+.hints a:focus-visible {
+  color: var(--w-primary);
 }
 
 .homeLink {

--- a/components/Page404.tsx
+++ b/components/Page404.tsx
@@ -24,6 +24,14 @@ export function Page404({ site, pageId, error }: types.PageProps) {
             moved.
           </p>
 
+          <p className={styles.hints}>
+            <a href='/'>Home</a>
+            <span aria-hidden='true'> · </span>
+            <a href='/llms.txt'>llms.txt</a>
+            <span aria-hidden='true'> · </span>
+            <a href='/sitemap.xml'>sitemap.xml</a>
+          </p>
+
           <a className={styles.homeLink} href={config.host}>
             <svg
               viewBox='0 0 16 16'

--- a/components/SiteInfoPage.module.css
+++ b/components/SiteInfoPage.module.css
@@ -1,0 +1,49 @@
+.article {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--about-text);
+}
+
+.article h2 {
+  margin: 2rem 0 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.article p {
+  margin: 0 0 1rem;
+}
+
+.article ul {
+  margin: 0 0 1rem;
+  padding-left: 1.2rem;
+}
+
+.article li {
+  margin: 0.35rem 0;
+}
+
+.article a {
+  color: var(--about-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.footerNav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+}
+
+.footerNav a {
+  color: var(--about-muted);
+}
+
+.footerNav a:hover {
+  color: var(--about-accent);
+}

--- a/components/SiteInfoPage.tsx
+++ b/components/SiteInfoPage.tsx
@@ -1,0 +1,127 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import * as React from 'react'
+
+import aboutStyles from '@/components/AboutPage.module.css'
+import { ThemeToggle } from '@/components/wustep/ThemeToggle'
+import { github, host, linkedin, name, x } from '@/lib/config'
+
+import styles from './SiteInfoPage.module.css'
+
+export function SiteInfoPage({
+  title,
+  description,
+  path,
+  children
+}: {
+  title: string
+  description: string
+  path: string
+  children: React.ReactNode
+}) {
+  const [isDark, setIsDark] = React.useState(true)
+  const canonicalUrl = `${host}${path}`
+
+  React.useEffect(() => {
+    try {
+      const saved = localStorage.getItem('darkMode')
+      if (saved !== null) setIsDark(JSON.parse(saved) as boolean)
+    } catch {}
+  }, [])
+
+  React.useEffect(() => {
+    localStorage.setItem('darkMode', JSON.stringify(isDark))
+  }, [isDark])
+
+  return (
+    <>
+      <Head>
+        <title>{`${title} · ${name}`}</title>
+        <meta name='description' content={description} />
+        <link rel='canonical' href={canonicalUrl} />
+      </Head>
+      <main
+        className={`${aboutStyles.page} ${isDark ? aboutStyles.dark : aboutStyles.light}`}
+      >
+        <div className={aboutStyles.glow} aria-hidden='true' />
+        <div className={aboutStyles.container}>
+          <header className={aboutStyles.header}>
+            <div className={aboutStyles.headerLeft}>
+              <Link href='/' className={aboutStyles.wordmark}>
+                <h1 className={aboutStyles.nameRow}>{name}</h1>
+              </Link>
+              <span className={aboutStyles.title}>{title}</span>
+            </div>
+            <nav className={aboutStyles.nav} aria-label='Social'>
+              <ThemeToggle
+                isDark={isDark}
+                onToggle={() => setIsDark(!isDark)}
+                className={aboutStyles.themeToggle}
+              />
+              {x && (
+                <a
+                  href={`https://x.com/${x}`}
+                  className={aboutStyles.navIcon}
+                  aria-label='X (Twitter)'
+                >
+                  <XIcon />
+                </a>
+              )}
+              {linkedin && (
+                <a
+                  href={`https://linkedin.com/in/${linkedin}`}
+                  className={aboutStyles.navIcon}
+                  aria-label='LinkedIn'
+                >
+                  <LinkedInIcon />
+                </a>
+              )}
+              {github && (
+                <a
+                  href={`https://github.com/${github}`}
+                  className={aboutStyles.navIcon}
+                  aria-label='GitHub'
+                >
+                  <GitHubIcon />
+                </a>
+              )}
+            </nav>
+          </header>
+          <article className={styles.article}>{children}</article>
+          <footer className={aboutStyles.footer}>
+            <nav className={styles.footerNav} aria-label='Site'>
+              <Link href='/'>Home</Link>
+              <Link href='/contact'>Contact</Link>
+              <Link href='/privacy'>Privacy</Link>
+              <a href='/llms.txt'>llms.txt</a>
+            </nav>
+          </footer>
+        </div>
+      </main>
+    </>
+  )
+}
+
+function XIcon() {
+  return (
+    <svg viewBox='0 0 24 24' fill='currentColor'>
+      <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
+    </svg>
+  )
+}
+
+function GitHubIcon() {
+  return (
+    <svg viewBox='0 0 24 24' fill='currentColor'>
+      <path d='M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z' />
+    </svg>
+  )
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox='0 0 24 24' fill='currentColor'>
+      <path d='M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z' />
+    </svg>
+  )
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Browser (HTML + hydrated React)
 ## Rendering modes
 
 - **Homepage (`/`)** — pure static, no Notion data. See [`pages/index.tsx`](../pages/index.tsx).
-- **Notion pages (`/[pageId]`)** — ISR with 24h revalidate. Built paths come from the generated Notion index; unknown slugs fall through to `fallback: true`.
+- **Notion pages (`/[pageId]`)** — ISR with 24h revalidate. Built paths come from the generated Notion index; unknown slugs fall through to `fallback: 'blocking'` and 404 if they do not resolve.
 - **Sitemap** — static XML generated before the build. **Feed** — `getServerSideProps` with long CDN `Cache-Control`.
 - **Social image** — edge API route using `next/og`, regenerated on demand and cached by the CDN.
 - **Search** — client calls `/api/search-notion`, which proxies to Notion. Currently disabled (`isSearchEnabled: false`).

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -9,7 +9,7 @@ Notion pages are rendered by [`pages/[pageId].tsx`](../pages/[pageId].tsx) with 
 - Pages are statically generated at build time from the generated Notion index.
 - After deploy, each page is served from Vercel's edge cache.
 - A page is re-rendered on-demand at most once per 24 hours per region, and only when someone requests it.
-- `fallback: true` means pages not in the sitemap can still be generated on first request.
+- `fallback: 'blocking'` means pages not in the sitemap can still be generated on first request, without a 200 spinner shell. Missing pages return HTTP 404.
 - Error responses use `revalidate: 10` so transient failures clear quickly.
 
 **Effect:** normal page traffic almost never hits Notion. Most of the other caches exist to keep the _revalidation path_ fast and to protect the build/sitemap path.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -6,8 +6,9 @@ How a URL like `/articles` or `/my-post-slug-2bc5cb08cf2c8036a1e3cddcb2c61d97` b
 
 - `/` — custom static homepage, [`pages/index.tsx`](../pages/index.tsx). Does not touch Notion.
 - `/[pageId]` — catch-all for every Notion page, [`pages/[pageId].tsx`](../pages/[pageId].tsx).
-- `/sitemap.xml`, `/feed`, `/robots.txt`, `/site`, `/404`, `/_error` — special pages.
-- `/api/search-notion`, `/api/social-image` — API routes.
+- `/sitemap.xml`, `/feed`, `/robots.txt`, `/llms.txt`, `/openapi.json`, `/privacy`, `/contact`, `/site`, `/404`, `/_error` — special pages.
+- `/api/search-notion`, `/api/social-image`, `/api/owner-mode` — API routes.
+- `/about` redirects to `/`.
 
 ## Resolving `[pageId]` → recordMap
 
@@ -73,8 +74,8 @@ const allPageIds = [
 ]
 ```
 
-- `fallback: true` — paths outside this set still work; they're rendered on first request and cached from then on.
-- In dev, `paths: []` with `fallback: true` skips pre-rendering; slug resolution still uses the committed generated index.
+- `fallback: 'blocking'` — paths outside this set are rendered on first request (the response waits for `getStaticProps`) and cached from then on. Unknown slugs return `{ notFound: true }` so the HTTP status is a real 404, not a 200 app shell.
+- In dev, `paths: []` with `fallback: 'blocking'` skips pre-rendering; slug resolution still uses the committed generated index.
 
 ## Site map construction
 

--- a/lib/__tests__/accept.test.ts
+++ b/lib/__tests__/accept.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  markdownContentType,
+  normalizeRequestPath,
+  prefersMarkdown
+} from '../accept'
+
+describe('prefersMarkdown', () => {
+  it('treats a markdown-only Accept as markdown', () => {
+    expect(prefersMarkdown('text/markdown')).toBe(true)
+    expect(prefersMarkdown('text/plain')).toBe(true)
+  })
+
+  it('keeps browser Accept headers on HTML', () => {
+    expect(
+      prefersMarkdown(
+        'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+      )
+    ).toBe(false)
+  })
+
+  it('does not treat */* as markdown', () => {
+    expect(prefersMarkdown('*/*')).toBe(false)
+    expect(prefersMarkdown(null)).toBe(false)
+  })
+
+  it('prefers the higher-q type when both are offered', () => {
+    expect(prefersMarkdown('text/html;q=0.9, text/markdown;q=1')).toBe(true)
+    expect(prefersMarkdown('text/markdown;q=0.1, text/html')).toBe(false)
+  })
+})
+
+describe('markdownContentType', () => {
+  it('uses text/plain when that is the preferred offer', () => {
+    expect(markdownContentType('text/plain')).toBe('text/plain; charset=utf-8')
+  })
+
+  it('defaults to text/markdown', () => {
+    expect(markdownContentType('text/markdown')).toBe(
+      'text/markdown; charset=utf-8'
+    )
+  })
+})
+
+describe('normalizeRequestPath', () => {
+  it('strips a trailing slash except on root', () => {
+    expect(normalizeRequestPath('/')).toBe('/')
+    expect(normalizeRequestPath('/privacy/')).toBe('/privacy')
+    expect(normalizeRequestPath('contact')).toBe('/contact')
+  })
+})

--- a/lib/__tests__/agent-content.test.ts
+++ b/lib/__tests__/agent-content.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getLlmsTxt,
+  getOpenApiDocument,
+  markdownForPath
+} from '../agent-content'
+import { apiError } from '../api-error'
+
+describe('markdownForPath', () => {
+  it('serves the homepage and about as the same markdown', () => {
+    const home = markdownForPath('/')
+    const about = markdownForPath('/about')
+    expect(home.status).toBe(200)
+    expect(about.body).toBe(home.body)
+    expect(home.body).toMatch(/^# Stephen Wu/m)
+    expect(home.body).toContain('Accept: text/markdown')
+  })
+
+  it('returns a 404 markdown body for unknown paths', () => {
+    const missing = markdownForPath('/this-path-does-not-exist-xyz')
+    expect(missing.status).toBe(404)
+    expect(missing.body).toContain('/llms.txt')
+    expect(missing.body).toContain('/sitemap.xml')
+  })
+
+  it('knows published Notion slugs', () => {
+    const page = markdownForPath('/headspace')
+    expect(page.status).toBe(200)
+    expect(page.body).toContain('https://wustep.me/headspace')
+  })
+})
+
+describe('getLlmsTxt', () => {
+  it('identifies the site and when to use it', () => {
+    const text = getLlmsTxt()
+    expect(text).toContain('wustep.me')
+    expect(text).toMatch(/## When to use this/)
+    expect(text).toContain('as a product, SaaS, or public data API')
+    expect(text).toContain('/prompting')
+    expect(text).toContain('/lenses')
+    expect(text).toContain('/playground')
+    expect(text).toContain('Accept: text/markdown')
+  })
+})
+
+describe('getOpenApiDocument', () => {
+  it('describes real public surfaces with unique operationIds', () => {
+    const spec = getOpenApiDocument()
+    const operations = Object.values(spec.paths).flatMap((pathItem) =>
+      Object.values(pathItem).map((op) => op.operationId)
+    )
+    expect(new Set(operations).size).toBe(operations.length)
+    expect(operations.every(Boolean)).toBe(true)
+    expect(spec.paths['/'].get.description).toBeTruthy()
+    expect(JSON.stringify(spec)).not.toMatch(/\/users|\/orders|\/invoices/)
+    expect(Object.hasOwn(spec.paths, '/api/search-notion')).toBe(false)
+    expect(Object.hasOwn(spec.paths, '/api/owner-mode')).toBe(false)
+  })
+})
+
+describe('apiError', () => {
+  it('returns a structured error body', () => {
+    expect(apiError(404, 'not_found', 'Nothing here')).toEqual({
+      error: 'not_found',
+      message: 'Nothing here',
+      status: 404
+    })
+  })
+})

--- a/lib/accept.ts
+++ b/lib/accept.ts
@@ -1,0 +1,96 @@
+/**
+ * Lightweight Accept parsing for markdown content negotiation.
+ * Safe for Edge middleware — no Node-only or site-config imports.
+ */
+
+type AcceptOffer = {
+  type: string
+  q: number
+  index: number
+}
+
+function parseAccept(header: string | null | undefined): AcceptOffer[] {
+  if (!header) return []
+
+  return header.split(',').map((part, index) => {
+    const [rawType, ...params] = part.trim().split(';')
+    const type = (rawType ?? '').trim().toLowerCase()
+    let q = 1
+    for (const param of params) {
+      const [key, value] = param.trim().split('=')
+      if (key?.trim() === 'q' && value) {
+        const parsed = Number.parseFloat(value)
+        if (Number.isFinite(parsed)) q = parsed
+      }
+    }
+    return { type, q, index }
+  })
+}
+
+function best(
+  offers: AcceptOffer[],
+  match: (type: string) => boolean
+): AcceptOffer | undefined {
+  return offers
+    .filter((offer) => match(offer.type))
+    .toSorted((a, b) => b.q - a.q || a.index - b.index)[0]
+}
+
+function isMarkdownType(type: string) {
+  return type === 'text/markdown' || type === 'text/x-markdown'
+}
+
+function isPlainType(type: string) {
+  return type === 'text/plain'
+}
+
+function isHtmlType(type: string) {
+  return type === 'text/html' || type === 'application/xhtml+xml'
+}
+
+/**
+ * True when the client prefers markdown or plain text over HTML.
+ * Browser defaults (text/html plus a catch-all) stay on HTML.
+ */
+export function prefersMarkdown(header: string | null | undefined): boolean {
+  const offers = parseAccept(header)
+  if (offers.length === 0) return false
+
+  const markdown = best(
+    offers,
+    (type) => isMarkdownType(type) || isPlainType(type)
+  )
+  if (!markdown) return false
+
+  const html = best(offers, isHtmlType)
+  if (!html) return true
+  if (markdown.q !== html.q) return markdown.q > html.q
+  return markdown.index < html.index
+}
+
+export function markdownContentType(
+  header: string | null | undefined
+): 'text/markdown; charset=utf-8' | 'text/plain; charset=utf-8' {
+  const offers = parseAccept(header)
+  const markdown = best(offers, isMarkdownType)
+  const plain = best(offers, isPlainType)
+
+  if (
+    plain &&
+    (!markdown ||
+      plain.q > markdown.q ||
+      (plain.q === markdown.q && plain.index < markdown.index))
+  ) {
+    return 'text/plain; charset=utf-8'
+  }
+
+  return 'text/markdown; charset=utf-8'
+}
+
+export function normalizeRequestPath(pathname: string): string {
+  if (!pathname || pathname === '/') return '/'
+  const withLeading = pathname.startsWith('/') ? pathname : `/${pathname}`
+  return withLeading.length > 1 && withLeading.endsWith('/')
+    ? withLeading.slice(0, -1)
+    : withLeading
+}

--- a/lib/agent-content.ts
+++ b/lib/agent-content.ts
@@ -104,25 +104,13 @@ export function getPrivacyMarkdown() {
 
 ${siteUrl}/privacy
 
-wustep.me is a personal website. It is not a product, account system, or data business. There are no user accounts, no login cookies for visitors, and nothing here is sold or shared as a dataset.
+This is a personal site. No accounts, no cookies beyond hosting defaults, no data sales.
 
-## What this site collects
+Hosted on Vercel, which keeps normal server logs (IP, path, timestamp). I may use Vercel Analytics for anonymous page-view counts. You can block that with their \`va-disable\` flag.
 
-The site is hosted on Vercel. Like most sites on that platform, requests can produce standard server and CDN logs (IP address, user agent, requested path, and timestamps). Those logs exist so the host can operate the site, debug errors, and absorb abuse. I do not run an advertising pixel and I do not sell visitor data.
+Writing comes from public Notion pages. If it's on wustep.me, it's public. Playground experiments run in your browser.
 
-Vercel Analytics may record anonymous page views. It is used to understand which pages people actually read. Owner-mode traffic on my own browser is excluded. You can also opt out of Vercel Analytics in the usual ways (their \`va-disable\` flag, or blocking the analytics script).
-
-## Content on this site
-
-Most writing is authored in Notion and published here because those pages are publicly shared. If a note is on wustep.me, treat it as public. Images and social-preview cards are generated from that public content.
-
-The contact page lists public social profiles. A leftover Notion contact form may still exist at an external Notion URL; anything you type there is subject to Notion's own terms, not a separate database I operate.
-
-## What I do not do
-
-I do not run a marketing list from this domain. I do not invent a customer CRM. I do not use visitor data for credit, employment, or insurance decisions. If you email or message me on a social network, that conversation lives on that network.
-
-Questions: see [Contact](${absolute('/contact')}) or [llms.txt](${absolute('/llms.txt')}).
+Questions: see [Contact](${absolute('/contact')}).
 `
 }
 
@@ -131,15 +119,7 @@ export function getContactMarkdown() {
 
 ${siteUrl}/contact
 
-The best way to reach me is on the public profiles I already use. I do not publish a phone number.
-
-- [X / Twitter](${xUrl}) — usually the fastest
-- [GitHub](${githubUrl}) — issues and code
-- [LinkedIn](${linkedinUrl}) — work-related notes
-
-There is also a short [Notion contact form](${notionContactUrl}) if you prefer a form to a public reply. I read it when I can; I do not promise a service-level response. This is a personal site.
-
-If you are an agent looking for an API to integrate with, there isn't one. Start at [llms.txt](${absolute('/llms.txt')}) or the [homepage](${absolute('/')}) with \`Accept: text/markdown\`.
+I'm easiest to find as wustep on [X](${xUrl}), [GitHub](${githubUrl}), or [LinkedIn](${linkedinUrl}). There's also a [Notion contact form](${notionContactUrl}) if you'd rather not reply in public.
 `
 }
 

--- a/lib/agent-content.ts
+++ b/lib/agent-content.ts
@@ -1,0 +1,474 @@
+import { normalizeRequestPath } from './accept'
+import { canonicalPageMap } from './notion-index'
+import {
+  bioText,
+  githubUrl,
+  linkedinUrl,
+  notionContactUrl,
+  siteDomain,
+  siteJobTitle,
+  siteName,
+  siteUrl,
+  siteWorksFor,
+  writingPersonal,
+  writingSoftware,
+  xUrl
+} from './site-identity'
+
+const OVERRIDE_SLUGS = [
+  'articles',
+  'notes',
+  'projects',
+  'essays',
+  'updates',
+  'writing'
+] as const
+
+const FIRST_PARTY_PREFIXES = [
+  '/prompting',
+  '/lenses',
+  '/playground',
+  '/design'
+] as const
+
+const FIRST_PARTY_EXACT = new Set([
+  '/',
+  '/about',
+  '/privacy',
+  '/contact',
+  '/feed',
+  '/site',
+  '/owner'
+])
+
+function absolute(path: string) {
+  return `${siteUrl}${path}`
+}
+
+function writingList(
+  items: readonly { title: string; href: string; note: string }[]
+) {
+  return items
+    .map((item) => `- [${item.title}](${absolute(item.href)}) — ${item.note}`)
+    .join('\n')
+}
+
+export function getHomeMarkdown() {
+  return `# ${siteName}
+
+${bioText}
+
+**${siteJobTitle} at ${siteWorksFor}.** Previously software engineer at Notion (2022–2025) and Facebook (2019–2022). B.S. Computer Science & Engineering, Ohio State (2015–2019).
+
+## Writing
+
+Software:
+
+${writingList(writingSoftware)}
+
+Personal:
+
+${writingList(writingPersonal)}
+
+## Projects
+
+- [Lenses](${absolute('/lenses')}) — a canvas of lenses for seeing the world
+- [Playground](${absolute('/playground')}) — small web experiments
+- [Projects](${absolute('/projects')}) — a longer list of work and side projects
+
+## For agents
+
+This is a personal site, not a product API. Prefer \`Accept: text/markdown\` (or \`text/plain\`) on these pages.
+
+- [Home](${absolute('/')})
+- [Prompting](${absolute('/prompting')})
+- [Lenses](${absolute('/lenses')})
+- [Playground](${absolute('/playground')})
+- [Feed](${absolute('/feed')})
+- [Sitemap](${absolute('/sitemap.xml')})
+- [llms.txt](${absolute('/llms.txt')})
+- [OpenAPI](${absolute('/openapi.json')})
+- [Contact](${absolute('/contact')})
+- [Privacy](${absolute('/privacy')})
+
+## Links
+
+- [GitHub](${githubUrl})
+- [LinkedIn](${linkedinUrl})
+- [X](${xUrl})
+`
+}
+
+export function getPrivacyMarkdown() {
+  return `# Privacy — ${siteName}
+
+${siteUrl}/privacy
+
+wustep.me is a personal website. It is not a product, account system, or data business. There are no user accounts, no login cookies for visitors, and nothing here is sold or shared as a dataset.
+
+## What this site collects
+
+The site is hosted on Vercel. Like most sites on that platform, requests can produce standard server and CDN logs (IP address, user agent, requested path, and timestamps). Those logs exist so the host can operate the site, debug errors, and absorb abuse. I do not run an advertising pixel and I do not sell visitor data.
+
+Vercel Analytics may record anonymous page views. It is used to understand which pages people actually read. Owner-mode traffic on my own browser is excluded. You can also opt out of Vercel Analytics in the usual ways (their \`va-disable\` flag, or blocking the analytics script).
+
+## Content on this site
+
+Most writing is authored in Notion and published here because those pages are publicly shared. If a note is on wustep.me, treat it as public. Images and social-preview cards are generated from that public content.
+
+The contact page lists public social profiles. A leftover Notion contact form may still exist at an external Notion URL; anything you type there is subject to Notion's own terms, not a separate database I operate.
+
+## What I do not do
+
+I do not run a marketing list from this domain. I do not invent a customer CRM. I do not use visitor data for credit, employment, or insurance decisions. If you email or message me on a social network, that conversation lives on that network.
+
+Questions: see [Contact](${absolute('/contact')}) or [llms.txt](${absolute('/llms.txt')}).
+`
+}
+
+export function getContactMarkdown() {
+  return `# Contact — ${siteName}
+
+${siteUrl}/contact
+
+The best way to reach me is on the public profiles I already use. I do not publish a phone number.
+
+- [X / Twitter](${xUrl}) — usually the fastest
+- [GitHub](${githubUrl}) — issues and code
+- [LinkedIn](${linkedinUrl}) — work-related notes
+
+There is also a short [Notion contact form](${notionContactUrl}) if you prefer a form to a public reply. I read it when I can; I do not promise a service-level response. This is a personal site.
+
+If you are an agent looking for an API to integrate with, there isn't one. Start at [llms.txt](${absolute('/llms.txt')}) or the [homepage](${absolute('/')}) with \`Accept: text/markdown\`.
+`
+}
+
+export function getPromptingMarkdown() {
+  return `# How to talk to coding agents
+
+A field guide to prompting coding agents — what works, what does not, and why.
+
+Read the HTML version at ${absolute('/prompting')}. Related notes live under /prompting/mindset, /prompting/techniques, /prompting/tree, /prompting/colleague, /prompting/equation, /prompting/orchestration, and /prompting/recap.
+
+This is writing on ${siteDomain}, not a hosted model API.
+`
+}
+
+export function getLensesMarkdown() {
+  return `# Lenses
+
+A canvas of lenses for seeing the world — headspace, dopamine, incentives, taste, status, and more. No single lens sees everything.
+
+HTML: ${absolute('/lenses')}
+`
+}
+
+export function getPlaygroundMarkdown() {
+  return `# Playground
+
+Small web experiments: games, visualizers, and other things that did not belong on a Notion page.
+
+HTML: ${absolute('/playground')}
+`
+}
+
+export function get404Markdown() {
+  return `# 404 — Page not found
+
+Nothing lives at this path on ${siteDomain}.
+
+Try:
+
+- [Home](${absolute('/')})
+- [llms.txt](${absolute('/llms.txt')})
+- [sitemap.xml](${absolute('/sitemap.xml')})
+`
+}
+
+function getStubMarkdown(path: string, title: string) {
+  return `# ${title}
+
+This page is published as HTML on ${siteName}'s site.
+
+- HTML: ${absolute(path)}
+- Site index: ${absolute('/llms.txt')}
+- Homepage markdown: request ${absolute('/')} with \`Accept: text/markdown\`
+`
+}
+
+export function isKnownSitePath(path: string): boolean {
+  const normalized = normalizeRequestPath(path)
+  if (FIRST_PARTY_EXACT.has(normalized)) return true
+  if (
+    FIRST_PARTY_PREFIXES.some(
+      (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`)
+    )
+  ) {
+    return true
+  }
+
+  const slug = normalized.slice(1)
+  if (!slug) return true
+  if ((OVERRIDE_SLUGS as readonly string[]).includes(slug)) return true
+  return Boolean(canonicalPageMap[slug])
+}
+
+export function markdownForPath(pathname: string): {
+  body: string
+  status: number
+} {
+  const path = normalizeRequestPath(pathname)
+
+  switch (path) {
+    case '/':
+    case '/about':
+      return { body: getHomeMarkdown(), status: 200 }
+    case '/privacy':
+      return { body: getPrivacyMarkdown(), status: 200 }
+    case '/contact':
+      return { body: getContactMarkdown(), status: 200 }
+    case '/prompting':
+      return { body: getPromptingMarkdown(), status: 200 }
+    case '/lenses':
+      return { body: getLensesMarkdown(), status: 200 }
+    case '/playground':
+      return { body: getPlaygroundMarkdown(), status: 200 }
+    default:
+      break
+  }
+
+  if (isKnownSitePath(path)) {
+    const title = path.slice(1) || siteName
+    return { body: getStubMarkdown(path, title), status: 200 }
+  }
+
+  return { body: get404Markdown(), status: 404 }
+}
+
+export function getLlmsTxt() {
+  return `# ${siteDomain}
+
+${siteName}'s personal site — writing, prompting notes, and playground projects.
+${siteUrl}
+
+## When to use this
+
+Use this site when you want ${siteName} (wustep): essays and notes, how he thinks about prompting coding agents, the Lenses deck, or small projects in the playground.
+
+Do not treat wustep.me as a product, SaaS, or public data API. There is no CRUD API to integrate with and no developer portal. The machine-readable files below describe the site itself.
+
+## Markdown
+
+Request \`Accept: text/markdown\` (or \`text/plain\`) on the homepage and other key pages. Those responses use \`Content-Type: text/markdown; charset=utf-8\` and \`Vary: Accept\`.
+
+## Important URLs
+
+- ${absolute('/')} — about / home
+- ${absolute('/about')} — same as home
+- ${absolute('/prompting')} — prompting notes
+- ${absolute('/lenses')} — lenses deck
+- ${absolute('/playground')} — experiments
+- ${absolute('/feed')} — RSS
+- ${absolute('/sitemap.xml')} — sitemap
+- ${absolute('/contact')} — how to reach me
+- ${absolute('/privacy')} — privacy notes
+- ${absolute('/llms.txt')} — this file
+- ${absolute('/openapi.json')} — the real public surfaces only
+
+## Contact
+
+- GitHub: ${githubUrl}
+- LinkedIn: ${linkedinUrl}
+- X: ${xUrl}
+`
+}
+
+export function getOpenApiDocument() {
+  const markdownOrHtml = {
+    '200': {
+      description:
+        'HTML for browsers; markdown when Accept prefers text/markdown or text/plain.',
+      content: {
+        'text/html': { schema: { type: 'string' } },
+        'text/markdown': { schema: { type: 'string' } }
+      }
+    }
+  }
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: siteDomain,
+      summary: `${siteName}'s personal site`,
+      description:
+        'Public, agent-facing surfaces for wustep.me. This is a personal site — writing, prompting notes, and playground projects — not a product API. There are no authenticated CRUD resources to integrate with.',
+      version: '1.0.0',
+      contact: {
+        name: siteName,
+        url: absolute('/contact')
+      }
+    },
+    servers: [{ url: siteUrl }],
+    paths: {
+      '/': {
+        get: {
+          operationId: 'getHome',
+          summary: 'Homepage / about',
+          description: `${siteName}'s homepage. Send Accept: text/markdown for a text index.`,
+          responses: markdownOrHtml
+        }
+      },
+      '/about': {
+        get: {
+          operationId: 'getAbout',
+          summary: 'About (same as home)',
+          description:
+            'Redirects to / in HTML; markdown is the same as the homepage.',
+          responses: markdownOrHtml
+        }
+      },
+      '/contact': {
+        get: {
+          operationId: 'getContact',
+          summary: 'Contact',
+          description:
+            'How to reach Stephen. Public socials only; no phone number.',
+          responses: markdownOrHtml
+        }
+      },
+      '/privacy': {
+        get: {
+          operationId: 'getPrivacy',
+          summary: 'Privacy',
+          description:
+            'What this personal site collects (hosting logs, optional analytics) and what it does not.',
+          responses: markdownOrHtml
+        }
+      },
+      '/prompting': {
+        get: {
+          operationId: 'getPrompting',
+          summary: 'Prompting notes',
+          description: 'Field guide to talking to coding agents.',
+          responses: markdownOrHtml
+        }
+      },
+      '/lenses': {
+        get: {
+          operationId: 'getLenses',
+          summary: 'Lenses',
+          description: 'A canvas of lenses for seeing the world.',
+          responses: markdownOrHtml
+        }
+      },
+      '/playground': {
+        get: {
+          operationId: 'getPlayground',
+          summary: 'Playground',
+          description: 'Small web experiments.',
+          responses: markdownOrHtml
+        }
+      },
+      '/feed': {
+        get: {
+          operationId: 'getFeed',
+          summary: 'RSS feed',
+          description:
+            'RSS of published posts from the public Notion collection.',
+          responses: {
+            '200': {
+              description: 'RSS 2.0 XML',
+              content: { 'application/rss+xml': { schema: { type: 'string' } } }
+            }
+          }
+        }
+      },
+      '/sitemap.xml': {
+        get: {
+          operationId: 'getSitemap',
+          summary: 'Sitemap',
+          description: 'Static sitemap of public pages.',
+          responses: {
+            '200': {
+              description: 'XML sitemap',
+              content: { 'application/xml': { schema: { type: 'string' } } }
+            }
+          }
+        }
+      },
+      '/llms.txt': {
+        get: {
+          operationId: 'getLlmsTxt',
+          summary: 'Agent instructions',
+          description:
+            'When to use this site, important URLs, and markdown negotiation.',
+          responses: {
+            '200': {
+              description: 'Plain-text agent instructions',
+              content: { 'text/plain': { schema: { type: 'string' } } }
+            }
+          }
+        }
+      },
+      '/openapi.json': {
+        get: {
+          operationId: 'getOpenApi',
+          summary: 'OpenAPI document',
+          description: 'This specification.',
+          responses: {
+            '200': {
+              description: 'OpenAPI 3.1 JSON',
+              content: { 'application/json': { schema: { type: 'object' } } }
+            }
+          }
+        }
+      },
+      '/api/social-image': {
+        get: {
+          operationId: 'getSocialImage',
+          summary: 'Open Graph image',
+          description:
+            'Renders a 1200×630 PNG for link unfurls from a public Notion page id. Errors are JSON.',
+          parameters: [
+            {
+              name: 'id',
+              in: 'query',
+              required: false,
+              description: 'Notion page id. Defaults to the site root page.',
+              schema: { type: 'string' }
+            }
+          ],
+          responses: {
+            '200': {
+              description: 'PNG image',
+              content: {
+                'image/png': { schema: { type: 'string', format: 'binary' } }
+              }
+            },
+            '400': {
+              description: 'Invalid page id or workspace mismatch',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/ApiError' }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    components: {
+      schemas: {
+        ApiError: {
+          type: 'object',
+          required: ['error', 'message', 'status'],
+          properties: {
+            error: { type: 'string' },
+            message: { type: 'string' },
+            status: { type: 'integer' }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/api-error.ts
+++ b/lib/api-error.ts
@@ -1,0 +1,36 @@
+import type { NextApiResponse } from 'next'
+
+export type ApiErrorBody = {
+  error: string
+  message: string
+  status: number
+}
+
+export function apiError(
+  status: number,
+  error: string,
+  message = error
+): ApiErrorBody {
+  return { error, message, status }
+}
+
+export function sendApiError(
+  res: NextApiResponse,
+  status: number,
+  error: string,
+  message = error
+) {
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  return res.status(status).json(apiError(status, error, message))
+}
+
+export function apiErrorResponse(
+  status: number,
+  error: string,
+  message = error
+): Response {
+  return Response.json(apiError(status, error, message), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' }
+  })
+}

--- a/lib/site-identity.ts
+++ b/lib/site-identity.ts
@@ -1,0 +1,128 @@
+/**
+ * Public identity for wustep.me — shared by the homepage, JSON-LD,
+ * markdown negotiation, and agent files. Keep this aligned with AboutPage.
+ */
+
+export const siteName = 'Stephen Wu'
+export const siteDomain = 'wustep.me'
+export const siteUrl = `https://${siteDomain}`
+export const siteJobTitle = 'Tech Lead Manager'
+export const siteWorksFor = 'Notion'
+export const siteWorksForUrl = 'https://notion.com'
+export const siteTagline = 'Engineering at Notion'
+
+export const githubHandle = 'wustep'
+export const linkedinHandle = 'wustep'
+export const xHandle = 'wustep'
+
+export const githubUrl = `https://github.com/${githubHandle}`
+export const linkedinUrl = `https://linkedin.com/in/${linkedinHandle}`
+export const xUrl = `https://x.com/${xHandle}`
+
+export const sameAs = [githubUrl, linkedinUrl, xUrl] as const
+
+// Plain-text mirror of the homepage bio — used for meta, JSON-LD, and markdown.
+export const bioText = `I'm Stephen, a product & design engineer who now also manages engineers. I think a lot about tools for thought, software design, and personal philosophy. I grew up mostly in Toledo, Ohio, and live in San Francisco now. I also enjoy roguelike deckbuilders, piano improvisation, and making random web projects.`
+
+export const workHistory = [
+  {
+    company: 'Notion',
+    icon: 'notion',
+    url: siteWorksForUrl,
+    roles: [
+      { title: 'Tech Lead Manager', period: '2025–' },
+      { title: 'Software Engineer', period: '2022–2025' }
+    ]
+  },
+  {
+    company: 'Facebook',
+    icon: 'facebook',
+    roles: [{ title: 'Software Engineer', period: '2019–2022' }]
+  },
+  {
+    company: 'Ohio State',
+    icon: 'osu',
+    roles: [
+      { title: 'B.S. Computer Science & Engineering', period: '2015–2019' }
+    ]
+  }
+]
+
+export const writingSoftware = [
+  {
+    title: 'Prompting',
+    href: '/prompting',
+    note: 'talking to coding agents'
+  },
+  {
+    title: 'Advice for students',
+    href: '/advice-students',
+    note: 'career pathfinding'
+  },
+  {
+    title: 'Graphs of knowledge',
+    href: '/cs-knowledge-graph',
+    note: 'careers as infinite trees'
+  },
+  {
+    title: "Don't thrash the user",
+    href: '/thrash',
+    note: 'empathetic ui/ux'
+  }
+] as const
+
+export const writingPersonal = [
+  {
+    title: 'Headspace',
+    href: '/headspace',
+    note: 'identity, growth, thought-space'
+  },
+  {
+    title: 'Foraging',
+    href: '/foraging',
+    note: 'ADHD, dopamine, attention'
+  },
+  {
+    title: 'On philosophy',
+    href: '/philosophy',
+    note: 'moral philosophy, lenses'
+  },
+  {
+    title: "oct '25",
+    href: '/oct-25',
+    note: 'life update'
+  }
+] as const
+
+export const notionContactUrl =
+  'https://wustep.notion.site/1425cb08cf2c80cc89d4f322774aa02b'
+
+export function personJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Person',
+        '@id': `${siteUrl}/#person`,
+        name: siteName,
+        url: siteUrl,
+        description: bioText,
+        jobTitle: siteJobTitle,
+        worksFor: {
+          '@type': 'Organization',
+          name: siteWorksFor,
+          url: siteWorksForUrl
+        },
+        sameAs: [...sameAs]
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${siteUrl}/#website`,
+        name: siteName,
+        url: siteUrl,
+        description: bioText,
+        author: { '@id': `${siteUrl}/#person` }
+      }
+    ]
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { markdownContentType, prefersMarkdown } from '@/lib/accept'
+import { markdownForPath } from '@/lib/agent-content'
+
+export const config = {
+  matcher: [
+    // Skip Next internals, API routes, and files with extensions
+    // (llms.txt, openapi.json, sitemap.xml, images, etc.).
+    '/((?!_next/|api/|favicon.ico|.*\\.[\\w]+$).*)'
+  ]
+}
+
+function withVaryAccept(response: NextResponse) {
+  const existing = response.headers.get('Vary')
+  if (!existing) {
+    response.headers.set('Vary', 'Accept')
+    return response
+  }
+  const parts = existing.split(',').map((part) => part.trim())
+  if (!parts.some((part) => part.toLowerCase() === 'accept')) {
+    response.headers.set('Vary', `${existing}, Accept`)
+  }
+  return response
+}
+
+export function middleware(request: NextRequest) {
+  const accept = request.headers.get('accept')
+
+  if (!prefersMarkdown(accept)) {
+    return withVaryAccept(NextResponse.next())
+  }
+
+  const { body, status } = markdownForPath(request.nextUrl.pathname)
+  return new NextResponse(body, {
+    status,
+    headers: {
+      'Content-Type': markdownContentType(accept),
+      Vary: 'Accept',
+      'Cache-Control': 'public, max-age=0, s-maxage=3600'
+    }
+  })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { markdownContentType, prefersMarkdown } from '@/lib/accept'
-import { markdownForPath } from '@/lib/agent-content'
+import { prefersMarkdown } from '@/lib/accept'
 
 export const config = {
   matcher: [
@@ -25,24 +24,18 @@ function withVaryAccept(response: NextResponse) {
 }
 
 export function middleware(request: NextRequest) {
-  const accept = request.headers.get('accept')
-
-  if (!prefersMarkdown(accept)) {
+  if (!prefersMarkdown(request.headers.get('accept'))) {
     return withVaryAccept(NextResponse.next())
   }
 
-  const { body, status } = markdownForPath(request.nextUrl.pathname)
-  const headers = {
-    'Content-Type': markdownContentType(accept),
-    Vary: 'Accept',
-    'Cache-Control': 'public, max-age=0, s-maxage=3600'
-  }
-
-  // HEAD must still carry Content-Type — `curl -sI` and acceptmarkdown
-  // scanners use it. An empty body avoids some hosts stripping the header.
-  if (request.method === 'HEAD') {
-    return new NextResponse(null, { status, headers })
-  }
-
-  return new NextResponse(body, { status, headers })
+  // Rewrite to a pages API route. Vercel drops Content-Type from empty
+  // middleware HEAD bodies, which breaks `curl -sI` / acceptmarkdown.
+  // Pass the original path in a header — rewritten query strings do not
+  // reliably reach pages API routes.
+  const headers = new Headers(request.headers)
+  headers.set('x-markdown-path', request.nextUrl.pathname)
+  const url = request.nextUrl.clone()
+  url.pathname = '/api/site-markdown'
+  url.search = ''
+  return NextResponse.rewrite(url, { request: { headers } })
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,12 +32,17 @@ export function middleware(request: NextRequest) {
   }
 
   const { body, status } = markdownForPath(request.nextUrl.pathname)
-  return new NextResponse(body, {
-    status,
-    headers: {
-      'Content-Type': markdownContentType(accept),
-      Vary: 'Accept',
-      'Cache-Control': 'public, max-age=0, s-maxage=3600'
-    }
-  })
+  const headers = {
+    'Content-Type': markdownContentType(accept),
+    Vary: 'Accept',
+    'Cache-Control': 'public, max-age=0, s-maxage=3600'
+  }
+
+  // HEAD must still carry Content-Type — `curl -sI` and acceptmarkdown
+  // scanners use it. An empty body avoids some hosts stripping the header.
+  if (request.method === 'HEAD') {
+    return new NextResponse(null, { status, headers })
+  }
+
+  return new NextResponse(body, { status, headers })
 }

--- a/next.config.js
+++ b/next.config.js
@@ -47,12 +47,6 @@ export default withBundleAnalyzer({
         permanent: true
       },
       {
-        source: '/contact',
-        destination:
-          'https://wustep.notion.site/1425cb08cf2c80cc89d4f322774aa02b',
-        permanent: true
-      },
-      {
         source: '/articles/:slug',
         destination: '/:slug',
         permanent: true
@@ -76,6 +70,30 @@ export default withBundleAnalyzer({
         headers: [
           { key: 'Access-Control-Allow-Origin', value: 'https://giscus.app' }
         ]
+      },
+      {
+        source: '/',
+        headers: [{ key: 'Vary', value: 'Accept' }]
+      },
+      {
+        source: '/privacy',
+        headers: [{ key: 'Vary', value: 'Accept' }]
+      },
+      {
+        source: '/contact',
+        headers: [{ key: 'Vary', value: 'Accept' }]
+      },
+      {
+        source: '/prompting',
+        headers: [{ key: 'Vary', value: 'Accept' }]
+      },
+      {
+        source: '/lenses',
+        headers: [{ key: 'Vary', value: 'Accept' }]
+      },
+      {
+        source: '/playground',
+        headers: [{ key: 'Vary', value: 'Accept' }]
       }
     ]
   },

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -36,6 +36,10 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
   try {
     const props = await resolveNotionPage(domain, normalizedPageId)
 
+    if (props.error?.statusCode === 404) {
+      return { notFound: true, revalidate: 10 }
+    }
+
     return { props, revalidate: 1800 }
   } catch (err: unknown) {
     console.error('page error', domain, requestedPageId, err)
@@ -70,7 +74,7 @@ export async function getStaticPaths() {
   if (isDev || process.env.SKIP_NOTION_STATIC_BUILD === 'true') {
     return {
       paths: [],
-      fallback: true
+      fallback: 'blocking'
     }
   }
 
@@ -85,7 +89,7 @@ export async function getStaticPaths() {
 
   const staticPaths = {
     paths: allPageIds.map((pageId) => ({ params: { pageId } })),
-    fallback: true
+    fallback: 'blocking'
   }
 
   return staticPaths

--- a/pages/api/owner-mode.ts
+++ b/pages/api/owner-mode.ts
@@ -1,5 +1,6 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
+import { type NextApiRequest, type NextApiResponse } from 'next'
 
+import { apiError } from '@/lib/api-error'
 import {
   clearOwnerCookie,
   createOwnerCookie,
@@ -10,7 +11,17 @@ import {
 
 type OwnerModeResponse = {
   error?: string
+  message?: string
+  status?: number
   isOwner: boolean
+}
+
+function ownerError(
+  status: number,
+  error: string,
+  message = error
+): OwnerModeResponse {
+  return { ...apiError(status, error, message), isOwner: false }
 }
 
 export default function ownerMode(
@@ -18,6 +29,7 @@ export default function ownerMode(
   res: NextApiResponse<OwnerModeResponse>
 ) {
   res.setHeader('Cache-Control', 'private, no-store')
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
 
   if (req.method === 'GET') {
     return res.status(200).json({ isOwner: isOwnerRequest(req) })
@@ -30,25 +42,22 @@ export default function ownerMode(
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'GET, POST, DELETE')
-    return res.status(405).json({
-      error: 'Method not allowed',
-      isOwner: false
-    })
+    return res
+      .status(405)
+      .json(ownerError(405, 'method_not_allowed', 'Use GET, POST, or DELETE.'))
   }
 
   if (!isOwnerModeConfigured()) {
-    return res.status(503).json({
-      error: 'Owner mode is not configured.',
-      isOwner: false
-    })
+    return res
+      .status(503)
+      .json(ownerError(503, 'not_configured', 'Owner mode is not configured.'))
   }
 
   const secret = typeof req.body?.secret === 'string' ? req.body.secret : ''
   if (!secret || secret.length > 512 || !verifyOwnerSecret(secret)) {
-    return res.status(401).json({
-      error: 'That owner key is not valid.',
-      isOwner: false
-    })
+    return res
+      .status(401)
+      .json(ownerError(401, 'invalid_secret', 'That owner key is not valid.'))
   }
 
   res.setHeader('Set-Cookie', createOwnerCookie())

--- a/pages/api/search-notion.ts
+++ b/pages/api/search-notion.ts
@@ -1,5 +1,7 @@
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
+import { sendApiError } from '@/lib/api-error'
+
 import type * as types from '../../lib/types'
 import { search } from '../../lib/notion'
 
@@ -8,16 +10,26 @@ export default async function searchNotion(
   res: NextApiResponse
 ) {
   if (req.method !== 'POST') {
-    return res.status(405).send({ error: 'method not allowed' })
+    res.setHeader('Allow', 'POST')
+    return sendApiError(
+      res,
+      405,
+      'method_not_allowed',
+      'This endpoint only accepts POST.'
+    )
   }
 
-  const searchParams: types.SearchParams = req.body
+  try {
+    const searchParams: types.SearchParams = req.body
+    const results = await search(searchParams)
 
-  const results = await search(searchParams)
-
-  res.setHeader(
-    'Cache-Control',
-    'public, s-maxage=300, max-age=60, stale-while-revalidate=3600'
-  )
-  res.status(200).json(results)
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=300, max-age=60, stale-while-revalidate=3600'
+    )
+    return res.status(200).json(results)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Notion search failed'
+    return sendApiError(res, 502, 'search_failed', message)
+  }
 }

--- a/pages/api/site-markdown.ts
+++ b/pages/api/site-markdown.ts
@@ -1,0 +1,49 @@
+import { type NextApiRequest, type NextApiResponse } from 'next'
+
+import { markdownContentType } from '@/lib/accept'
+import { markdownForPath } from '@/lib/agent-content'
+import { sendApiError } from '@/lib/api-error'
+
+/**
+ * Internal handler for Accept: text/markdown. Middleware rewrites here so
+ * HEAD (`curl -sI`) keeps Content-Type — Vercel strips it from empty
+ * middleware responses. Not a public product API.
+ */
+export default function siteMarkdown(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD')
+    return sendApiError(
+      res,
+      405,
+      'method_not_allowed',
+      'Use GET or HEAD with Accept: text/markdown on site pages.'
+    )
+  }
+
+  const headerPath = req.headers['x-markdown-path']
+  const queryPath = req.query.path
+  const path =
+    typeof headerPath === 'string'
+      ? headerPath
+      : typeof queryPath === 'string'
+        ? queryPath
+        : '/'
+  const { body, status } = markdownForPath(path)
+  const type = markdownContentType(
+    typeof req.headers.accept === 'string' ? req.headers.accept : null
+  )
+
+  res.setHeader('Content-Type', type)
+  res.setHeader('Vary', 'Accept')
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600')
+  res.setHeader('Content-Length', String(Buffer.byteLength(body)))
+  res.status(status)
+  if (req.method === 'HEAD') {
+    res.end()
+    return
+  }
+  res.send(body)
+}

--- a/pages/api/social-image.tsx
+++ b/pages/api/social-image.tsx
@@ -11,6 +11,7 @@ import {
   parsePageId
 } from 'notion-utils'
 
+import { apiErrorResponse } from '@/lib/api-error'
 import * as libConfig from '@/lib/config'
 import interSemiBoldFont from '@/lib/fonts/inter-semibold'
 import { mapImageUrl } from '@/lib/map-image-url'
@@ -21,21 +22,30 @@ export const runtime = 'edge'
 
 export default async function OGImage(
   req: NextApiRequest,
-  res: NextApiResponse
+  _res: NextApiResponse
 ) {
   const { searchParams } = new URL(req.url!)
   const pageId = parsePageId(
     searchParams.get('id') || libConfig.rootNotionPageId
   )
   if (!pageId) {
-    return new Response('Invalid notion page id', { status: 400 })
+    return apiErrorResponse(400, 'invalid_page_id', 'Invalid notion page id')
   }
 
-  const pageInfoOrError = await getNotionPageInfo({ pageId })
+  let pageInfoOrError: Awaited<ReturnType<typeof getNotionPageInfo>>
+  try {
+    pageInfoOrError = await getNotionPageInfo({ pageId })
+  } catch (err: unknown) {
+    const message =
+      err instanceof Error ? err.message : 'Could not load Notion page'
+    return apiErrorResponse(502, 'page_lookup_failed', message)
+  }
   if (pageInfoOrError.type === 'error') {
-    return res.status(pageInfoOrError.error.statusCode).send({
-      error: pageInfoOrError.error.message
-    })
+    return apiErrorResponse(
+      pageInfoOrError.error.statusCode,
+      'page_error',
+      pageInfoOrError.error.message ?? 'Could not render social image'
+    )
   }
   const pageInfo = pageInfoOrError.data
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -11,46 +11,17 @@ export default function ContactPage() {
   return (
     <SiteInfoPage
       title='Contact'
-      description={`How to reach ${siteName}. Public social profiles only — no phone number.`}
+      description={`How to reach ${siteName}.`}
       path='/contact'
     >
       <p>
-        I am easy to find under the same handle, wustep, on the networks I
-        already use. This is a personal site, so there is no support inbox, no
-        sales form, and no phone number. If you are writing because something
-        here was useful — or wrong — I would rather hear it in a place I already
-        check than through a one-off widget.
-      </p>
-      <h2>Public profiles</h2>
-      <ul>
-        <li>
-          <a href={xUrl}>X / Twitter</a> — usually the fastest way to get a
-          short reply
-        </li>
-        <li>
-          <a href={githubUrl}>GitHub</a> — issues and code, including this
-          site&apos;s repo
-        </li>
-        <li>
-          <a href={linkedinUrl}>LinkedIn</a> — work-related notes
-        </li>
-      </ul>
-      <p>
-        There is also a short{' '}
+        I&apos;m easiest to find as wustep on <a href={xUrl}>X</a>,{' '}
+        <a href={githubUrl}>GitHub</a>, or <a href={linkedinUrl}>LinkedIn</a>.
+        There&apos;s also a{' '}
         <a href={notionContactUrl} rel='noopener noreferrer'>
           Notion contact form
         </a>{' '}
-        if you prefer a form to a public reply. I read it when I can. I do not
-        promise a service-level response, and I will not invent an on-call
-        rotation for a personal homepage.
-      </p>
-      <h2>If you are an agent</h2>
-      <p>
-        There is no product API to integrate with here. Start at{' '}
-        <a href='/llms.txt'>llms.txt</a> or request the homepage with{' '}
-        <code>Accept: text/markdown</code>. The{' '}
-        <a href='/openapi.json'>OpenAPI file</a> lists the real public surfaces
-        — pages, the feed, the sitemap — and nothing else.
+        if you&apos;d rather not reply in public.
       </p>
     </SiteInfoPage>
   )

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,57 @@
+import { SiteInfoPage } from '@/components/SiteInfoPage'
+import {
+  githubUrl,
+  linkedinUrl,
+  notionContactUrl,
+  siteName,
+  xUrl
+} from '@/lib/site-identity'
+
+export default function ContactPage() {
+  return (
+    <SiteInfoPage
+      title='Contact'
+      description={`How to reach ${siteName}. Public social profiles only — no phone number.`}
+      path='/contact'
+    >
+      <p>
+        I am easy to find under the same handle, wustep, on the networks I
+        already use. This is a personal site, so there is no support inbox, no
+        sales form, and no phone number. If you are writing because something
+        here was useful — or wrong — I would rather hear it in a place I already
+        check than through a one-off widget.
+      </p>
+      <h2>Public profiles</h2>
+      <ul>
+        <li>
+          <a href={xUrl}>X / Twitter</a> — usually the fastest way to get a
+          short reply
+        </li>
+        <li>
+          <a href={githubUrl}>GitHub</a> — issues and code, including this
+          site&apos;s repo
+        </li>
+        <li>
+          <a href={linkedinUrl}>LinkedIn</a> — work-related notes
+        </li>
+      </ul>
+      <p>
+        There is also a short{' '}
+        <a href={notionContactUrl} rel='noopener noreferrer'>
+          Notion contact form
+        </a>{' '}
+        if you prefer a form to a public reply. I read it when I can. I do not
+        promise a service-level response, and I will not invent an on-call
+        rotation for a personal homepage.
+      </p>
+      <h2>If you are an agent</h2>
+      <p>
+        There is no product API to integrate with here. Start at{' '}
+        <a href='/llms.txt'>llms.txt</a> or request the homepage with{' '}
+        <code>Accept: text/markdown</code>. The{' '}
+        <a href='/openapi.json'>OpenAPI file</a> lists the real public surfaces
+        — pages, the feed, the sitemap — and nothing else.
+      </p>
+    </SiteInfoPage>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,8 @@
 import Head from 'next/head'
 
-import { AboutPage, bioText } from '@/components/AboutPage'
+import { AboutPage } from '@/components/AboutPage'
 import { domain, host, name, x } from '@/lib/config'
+import { bioText, personJsonLd } from '@/lib/site-identity'
 
 const previewImage = `${host}/favicon-512x512.png`
 const canonicalUrl = `${host}/`
@@ -28,6 +29,10 @@ export default function IndexPage() {
         <meta name='twitter:title' content={name} />
         <meta name='twitter:description' content={bioText} />
         <meta name='twitter:image' content={previewImage} />
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd()) }}
+        />
       </Head>
       <AboutPage />
     </>

--- a/pages/llms.txt.tsx
+++ b/pages/llms.txt.tsx
@@ -1,0 +1,30 @@
+import type { GetServerSideProps } from 'next'
+
+import { getLlmsTxt } from '@/lib/agent-content'
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  if (req.method !== 'GET') {
+    res.statusCode = 405
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.write(
+      JSON.stringify({
+        error: 'method_not_allowed',
+        message: 'Use GET',
+        status: 405
+      })
+    )
+    res.end()
+    return { props: {} }
+  }
+
+  res.setHeader('Cache-Control', 'public, max-age=86400')
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  res.write(getLlmsTxt())
+  res.end()
+
+  return { props: {} }
+}
+
+export default function noop() {
+  return null
+}

--- a/pages/llms.txt.tsx
+++ b/pages/llms.txt.tsx
@@ -3,8 +3,9 @@ import type { GetServerSideProps } from 'next'
 import { getLlmsTxt } from '@/lib/agent-content'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-  if (req.method !== 'GET') {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
     res.statusCode = 405
+    res.setHeader('Allow', 'GET, HEAD')
     res.setHeader('Content-Type', 'application/json; charset=utf-8')
     res.write(
       JSON.stringify({
@@ -17,9 +18,13 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     return { props: {} }
   }
 
+  const body = getLlmsTxt()
   res.setHeader('Cache-Control', 'public, max-age=86400')
   res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-  res.write(getLlmsTxt())
+  res.setHeader('Content-Length', String(Buffer.byteLength(body)))
+  if (req.method === 'GET') {
+    res.write(body)
+  }
   res.end()
 
   return { props: {} }

--- a/pages/openapi.json.tsx
+++ b/pages/openapi.json.tsx
@@ -3,8 +3,9 @@ import type { GetServerSideProps } from 'next'
 import { getOpenApiDocument } from '@/lib/agent-content'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-  if (req.method !== 'GET') {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
     res.statusCode = 405
+    res.setHeader('Allow', 'GET, HEAD')
     res.setHeader('Content-Type', 'application/json; charset=utf-8')
     res.write(
       JSON.stringify({
@@ -17,9 +18,13 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     return { props: {} }
   }
 
+  const body = JSON.stringify(getOpenApiDocument(), null, 2)
   res.setHeader('Cache-Control', 'public, max-age=86400')
   res.setHeader('Content-Type', 'application/json; charset=utf-8')
-  res.write(JSON.stringify(getOpenApiDocument(), null, 2))
+  res.setHeader('Content-Length', String(Buffer.byteLength(body)))
+  if (req.method === 'GET') {
+    res.write(body)
+  }
   res.end()
 
   return { props: {} }

--- a/pages/openapi.json.tsx
+++ b/pages/openapi.json.tsx
@@ -1,0 +1,30 @@
+import type { GetServerSideProps } from 'next'
+
+import { getOpenApiDocument } from '@/lib/agent-content'
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  if (req.method !== 'GET') {
+    res.statusCode = 405
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.write(
+      JSON.stringify({
+        error: 'method_not_allowed',
+        message: 'Use GET',
+        status: 405
+      })
+    )
+    res.end()
+    return { props: {} }
+  }
+
+  res.setHeader('Cache-Control', 'public, max-age=86400')
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  res.write(JSON.stringify(getOpenApiDocument(), null, 2))
+  res.end()
+
+  return { props: {} }
+}
+
+export default function noop() {
+  return null
+}

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,56 +1,28 @@
 import { SiteInfoPage } from '@/components/SiteInfoPage'
-import { githubUrl, linkedinUrl, siteName, xUrl } from '@/lib/site-identity'
+import { siteName } from '@/lib/site-identity'
 
 export default function PrivacyPage() {
   return (
     <SiteInfoPage
       title='Privacy'
-      description={`${siteName}'s personal site: what is collected, what is not, and why this is not a data product.`}
+      description={`Privacy on ${siteName}'s personal site.`}
       path='/privacy'
     >
       <p>
-        wustep.me is a personal website. It is not a product, an account system,
-        or a data business. There are no visitor logins, no marketing list
-        collected from this domain, and nothing here is sold or rented as a
-        dataset. If you found this page because an agent asked whether the site
-        is legitimate, the short answer is: it is one person&apos;s public
-        writing and projects.
-      </p>
-      <h2>What this site collects</h2>
-      <p>
-        The site is hosted on Vercel. Incoming requests can produce ordinary
-        server and CDN logs — IP address, user agent, requested path, and a
-        timestamp. Those logs exist so the host can keep the site up, debug
-        errors, and absorb abuse. I do not run an advertising pixel and I do not
-        sell visitor data.
+        This is a personal site. There are no accounts, no cookies beyond
+        hosting defaults, and I don&apos;t sell data.
       </p>
       <p>
-        Vercel Analytics may record anonymous page views so I can see which
-        notes people actually read. Traffic from my own owner-mode session is
-        excluded. You can also opt out of Vercel Analytics in the usual ways
-        (their <code>va-disable</code> flag, or blocking the analytics script).
-      </p>
-      <h2>Content on this site</h2>
-      <p>
-        Most writing is authored in Notion and published here because those
-        pages are publicly shared. If a note is on wustep.me, treat it as
-        public. Social-preview images are generated from that same public
-        content. The playground experiments run in your browser; they do not
-        create an account.
-      </p>
-      <h2>What I do not do</h2>
-      <p>
-        I do not keep a customer CRM. I do not use visitor data for credit,
-        employment, or insurance decisions. If you write to me on{' '}
-        <a href={xUrl}>X</a>, <a href={githubUrl}>GitHub</a>, or{' '}
-        <a href={linkedinUrl}>LinkedIn</a>, that conversation lives on that
-        network, under that network&apos;s rules. A leftover Notion contact form
-        may still exist; anything typed there is subject to Notion&apos;s terms,
-        not a separate database I operate.
+        It&apos;s hosted on Vercel, which keeps normal server logs (IP, path,
+        timestamp). I may use Vercel Analytics for anonymous page-view counts.
+        You can block that with their <code>va-disable</code> flag.
       </p>
       <p>
-        Questions about this page belong on the{' '}
-        <a href='/contact'>contact page</a>.
+        Writing comes from public Notion pages. If it&apos;s on wustep.me,
+        it&apos;s public. Playground experiments run in your browser.
+      </p>
+      <p>
+        Questions? See <a href='/contact'>contact</a>.
       </p>
     </SiteInfoPage>
   )

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,57 @@
+import { SiteInfoPage } from '@/components/SiteInfoPage'
+import { githubUrl, linkedinUrl, siteName, xUrl } from '@/lib/site-identity'
+
+export default function PrivacyPage() {
+  return (
+    <SiteInfoPage
+      title='Privacy'
+      description={`${siteName}'s personal site: what is collected, what is not, and why this is not a data product.`}
+      path='/privacy'
+    >
+      <p>
+        wustep.me is a personal website. It is not a product, an account system,
+        or a data business. There are no visitor logins, no marketing list
+        collected from this domain, and nothing here is sold or rented as a
+        dataset. If you found this page because an agent asked whether the site
+        is legitimate, the short answer is: it is one person&apos;s public
+        writing and projects.
+      </p>
+      <h2>What this site collects</h2>
+      <p>
+        The site is hosted on Vercel. Incoming requests can produce ordinary
+        server and CDN logs — IP address, user agent, requested path, and a
+        timestamp. Those logs exist so the host can keep the site up, debug
+        errors, and absorb abuse. I do not run an advertising pixel and I do not
+        sell visitor data.
+      </p>
+      <p>
+        Vercel Analytics may record anonymous page views so I can see which
+        notes people actually read. Traffic from my own owner-mode session is
+        excluded. You can also opt out of Vercel Analytics in the usual ways
+        (their <code>va-disable</code> flag, or blocking the analytics script).
+      </p>
+      <h2>Content on this site</h2>
+      <p>
+        Most writing is authored in Notion and published here because those
+        pages are publicly shared. If a note is on wustep.me, treat it as
+        public. Social-preview images are generated from that same public
+        content. The playground experiments run in your browser; they do not
+        create an account.
+      </p>
+      <h2>What I do not do</h2>
+      <p>
+        I do not keep a customer CRM. I do not use visitor data for credit,
+        employment, or insurance decisions. If you write to me on{' '}
+        <a href={xUrl}>X</a>, <a href={githubUrl}>GitHub</a>, or{' '}
+        <a href={linkedinUrl}>LinkedIn</a>, that conversation lives on that
+        network, under that network&apos;s rules. A leftover Notion contact form
+        may still exist; anything typed there is subject to Notion&apos;s terms,
+        not a separate database I operate.
+      </p>
+      <p>
+        Questions about this page belong on the{' '}
+        <a href='/contact'>contact page</a>.
+      </p>
+    </SiteInfoPage>
+  )
+}

--- a/pages/robots.txt.tsx
+++ b/pages/robots.txt.tsx
@@ -3,8 +3,9 @@ import type { GetServerSideProps } from 'next'
 import { host } from '@/lib/config'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-  if (req.method !== 'GET') {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
     res.statusCode = 405
+    res.setHeader('Allow', 'GET, HEAD')
     res.setHeader('Content-Type', 'application/json')
     res.write(JSON.stringify({ error: 'method not allowed' }))
     res.end()
@@ -14,29 +15,30 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     }
   }
 
-  // cache for up to one day
-  res.setHeader('Cache-Control', 'public, max-age=86400, immutable')
-  res.setHeader('Content-Type', 'text/plain')
-
-  // only allow the site to be crawlable on the production deployment
-  if (process.env.VERCEL_ENV === 'production') {
-    res.write(`User-agent: *
+  const body =
+    process.env.VERCEL_ENV === 'production'
+      ? `User-agent: *
 Allow: /
 Disallow: /api/get-tweet-ast/*
 Disallow: /api/search-notion
 
 Sitemap: ${host}/sitemap.xml
 # llms.txt: ${host}/llms.txt
-`)
-  } else {
-    res.write(`User-agent: *
+`
+      : `User-agent: *
 Disallow: /
 
 Sitemap: ${host}/sitemap.xml
 # llms.txt: ${host}/llms.txt
-`)
-  }
+`
 
+  // cache for up to one day
+  res.setHeader('Cache-Control', 'public, max-age=86400, immutable')
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('Content-Length', String(Buffer.byteLength(body)))
+  if (req.method === 'GET') {
+    res.write(body)
+  }
   res.end()
 
   return {

--- a/pages/robots.txt.tsx
+++ b/pages/robots.txt.tsx
@@ -26,12 +26,14 @@ Disallow: /api/get-tweet-ast/*
 Disallow: /api/search-notion
 
 Sitemap: ${host}/sitemap.xml
+# llms.txt: ${host}/llms.txt
 `)
   } else {
     res.write(`User-agent: *
 Disallow: /
 
 Sitemap: ${host}/sitemap.xml
+# llms.txt: ${host}/llms.txt
 `)
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the [is-agentic.com scan](https://is-agentic.com/scan/wustep.me) findings that were actually wrong on this site (49/100 on 2026-08-21). This is a personal homepage, so the PR does **not** invent a SaaS API, a fake Organization street address, or a dummy developer portal just to move the score.

### What was actually broken

Unknown paths were a soft-404: `pages/[pageId].tsx` used `fallback: true` and rendered a 404 *page* as props, so HTTP stayed 200. Agents probing `/this-path-does-not-exist-xyz` concluded every URL exists.

`Accept: text/markdown` was ignored (HTML + no `Vary: Accept`). There was no `llms.txt`, no Person JSON-LD, no first-party `/privacy`, and `/contact` bounced to Notion. Existing `/api/*` errors were not consistently `{ error, message, status }`.

The homepage already server-renders an `<h1>` and well over 500 characters — the scan’s “no H1” look was likely a nested-link parse. I still moved the heading text into the `<h1>` itself, dropped the unnecessary `'use client'` on `AboutPage`, and added discreet Privacy / llms.txt links in the footer.

### What I did not fake

- No public CRUD/GraphQL “product API”
- No Organization NAP (Person JSON-LD, `worksFor: Notion` with name + url only)
- Repo `docs/` stays private developer notes; `/docs` is not a published product docs site (it was only “found” because of the soft-404)

### Agent surfaces

- Real HTTP 404 for missing slugs (`fallback: 'blocking'` + `{ notFound: true }`), with a short markdown 404 when `Accept: text/markdown`
- Middleware content negotiation on `/`, `/about`, `/privacy`, `/contact`, `/prompting`, `/lenses`, `/playground` — `Content-Type: text/markdown; charset=utf-8`, `Vary: Accept`
- `/llms.txt` with a **When to use this** section
- `/openapi.json` describing only real public pages/feed/sitemap/llms/social-image
- `/privacy` and `/contact` (500+ chars, existing socials, no phone number)
- `/about` still redirects to `/`
- HEAD works on those agent files (the scan uses `curl -sI`)

### Verify

Preview: https://me-git-cursor-agentic-scan-fixes-d877-wustep.vercel.app

```
curl -s -o /dev/null -w "%{http_code}" <preview>/this-path-does-not-exist-xyz
# 404

curl -sI -H 'Accept: text/markdown' <preview>/
# content-type: text/markdown; charset=utf-8
# vary: Accept
```

Also checked on the first preview deploy: `/privacy` and `/contact` 200 with 500+ chars, `/about` → `/`, homepage HTML has `<h1>Stephen Wu</h1>` + Person JSON-LD, API errors are `{ error, message, status }`. A follow-up commit makes HEAD return the same Content-Type (the first preview 405'd HEAD on `/llms.txt` / `/openapi.json`).

### Screenshots

Production / main (before) vs this branch (after). Homepage look is unchanged except the footer `Privacy` / `llms.txt` links. Headless Chrome rendered the after homepage in the default dark theme; production screenshot landed in light — same page, same toggle.

**Homepage — production**

[Homepage on production](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-home.png)

**Homepage — this branch** (full page, footer links at the bottom)

[Homepage on this branch](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-home-full.png)

**404 — production** (looks like a 404, but HTTP was 200)

[Production 404 page](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-404.png)

**404 — this branch** (HTTP 404, plus Home / llms.txt / sitemap.xml)

[New 404 page](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-404.png)

**Contact — this branch** (production `/contact` redirected off-site to Notion)

[New contact page](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-contact.png)

**Privacy — this branch** (new page)

[New privacy page](https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-privacy.png)

#### Notion Test Page ID

n/a — routing / agent files / first-party pages, not a Notion post.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379fca7f-38e6-4eb0-bd28-ccf7a6c2d877&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

